### PR TITLE
fix: routing caches not updating

### DIFF
--- a/packages/cli/bin/asteroids.dart
+++ b/packages/cli/bin/asteroids.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {

--- a/packages/cli/bin/contracts.dart
+++ b/packages/cli/bin/contracts.dart
@@ -1,5 +1,4 @@
 import 'package:cli/behavior/trader.dart';
-import 'package:cli/cache/contract_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 

--- a/packages/cli/bin/deals_in_progress.dart
+++ b/packages/cli/bin/deals_in_progress.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli_table/cli_table.dart';
 import 'package:types/prediction.dart';

--- a/packages/cli/bin/earning_per_ship.dart
+++ b/packages/cli/bin/earning_per_ship.dart
@@ -1,5 +1,3 @@
-import 'package:cli/cache/behavior_snapshot.dart';
-import 'package:cli/cache/ship_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:cli_table/cli_table.dart';
 import 'package:intl/intl.dart';

--- a/packages/cli/bin/exports_supply_chain.dart
+++ b/packages/cli/bin/exports_supply_chain.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/supply_chain.dart';
 

--- a/packages/cli/bin/extract_scores.dart
+++ b/packages/cli/bin/extract_scores.dart
@@ -1,4 +1,3 @@
-import 'package:cli/cache/market_price_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';
 import 'package:cli/plan/extraction_score.dart';

--- a/packages/cli/bin/find_mounts.dart
+++ b/packages/cli/bin/find_mounts.dart
@@ -1,16 +1,9 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/trading.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
-  final systemsCache = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: (_) => false,
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   // TODO(eseidel): Just use hq and command ship spec.
   final ships = await ShipSnapshot.load(db);
   final ship = ships.ships.first;

--- a/packages/cli/bin/fleet.dart
+++ b/packages/cli/bin/fleet.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli/nav/navigation.dart';

--- a/packages/cli/bin/fleet_charters.dart
+++ b/packages/cli/bin/fleet_charters.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli/nav/navigation.dart';

--- a/packages/cli/bin/fleet_closest_to.dart
+++ b/packages/cli/bin/fleet_closest_to.dart
@@ -1,19 +1,11 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
-import 'package:cli/nav/navigation.dart';
 import 'package:collection/collection.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {
   // For a given destination, compute the time to travel there for each ship.
   final destination = WaypointSymbol.fromString(argResults.rest[0]);
   final ships = await ShipSnapshot.load(db);
-  final systemsCache = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: await defaultSellsFuel(db),
-  );
+  final routePlanner = await defaultRoutePlanner(db);
 
   final travelTimes = <ShipSymbol, Duration>{};
 

--- a/packages/cli/bin/fleet_closest_to.dart
+++ b/packages/cli/bin/fleet_closest_to.dart
@@ -8,13 +8,11 @@ Future<void> command(Database db, ArgResults argResults) async {
   final destination = WaypointSymbol.fromString(argResults.rest[0]);
   final ships = await ShipSnapshot.load(db);
   final systemsCache = await db.systems.snapshotAllSystems();
-  final marketListings = await db.marketListings.snapshotAll();
-
   final systemConnectivity = await loadSystemConnectivity(db);
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systemsCache,
     systemConnectivity,
-    sellsFuel: defaultSellsFuel(marketListings),
+    sellsFuel: await defaultSellsFuel(db),
   );
 
   final travelTimes = <ShipSymbol, Duration>{};

--- a/packages/cli/bin/fleet_idle.dart
+++ b/packages/cli/bin/fleet_idle.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 
 // count the number of idle behaviors by FleetRole.

--- a/packages/cli/bin/fleet_needed_mounts.dart
+++ b/packages/cli/bin/fleet_needed_mounts.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 

--- a/packages/cli/bin/fleet_ship_to_buy.dart
+++ b/packages/cli/bin/fleet_ship_to_buy.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';

--- a/packages/cli/bin/fleet_systems.dart
+++ b/packages/cli/bin/fleet_systems.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 
 void main(List<String> args) async {

--- a/packages/cli/bin/fleet_value.dart
+++ b/packages/cli/bin/fleet_value.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/ships.dart';
 import 'package:collection/collection.dart';

--- a/packages/cli/bin/idle_queue.dart
+++ b/packages/cli/bin/idle_queue.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/idle_queue.dart';

--- a/packages/cli/bin/jumpgate.dart
+++ b/packages/cli/bin/jumpgate.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli/net/auth.dart';

--- a/packages/cli/bin/jumpgate_construction.dart
+++ b/packages/cli/bin/jumpgate_construction.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {

--- a/packages/cli/bin/jumpgates_to_scan.dart
+++ b/packages/cli/bin/jumpgates_to_scan.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/idle_queue.dart';
 

--- a/packages/cli/bin/market_listings.dart
+++ b/packages/cli/bin/market_listings.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli_table/cli_table.dart';

--- a/packages/cli/bin/market_nearby_buys.dart
+++ b/packages/cli/bin/market_nearby_buys.dart
@@ -1,15 +1,8 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/trading.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {
-  final systemsCache = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: (_) => false,
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   // TODO(eseidel): Just use hq and command ship spec.
   final ships = await ShipSnapshot.load(db);
   final ship = ships.ships.first;

--- a/packages/cli/bin/market_nearby_sells.dart
+++ b/packages/cli/bin/market_nearby_sells.dart
@@ -1,16 +1,10 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/trading.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
   final systemsCache = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: (_) => false,
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   final ships = await ShipSnapshot.load(db);
 
   const tradeSymbol = TradeSymbol.DIAMONDS;

--- a/packages/cli/bin/market_pairs.dart
+++ b/packages/cli/bin/market_pairs.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli_table/cli_table.dart';

--- a/packages/cli/bin/market_price_freshness.dart
+++ b/packages/cli/bin/market_price_freshness.dart
@@ -1,4 +1,3 @@
-import 'package:cli/cache/market_price_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:stats/stats.dart';
 

--- a/packages/cli/bin/market_price_ranges.dart
+++ b/packages/cli/bin/market_price_ranges.dart
@@ -1,4 +1,3 @@
-import 'package:cli/cache/market_price_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:stats/stats.dart';
 

--- a/packages/cli/bin/market_prices.dart
+++ b/packages/cli/bin/market_prices.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {

--- a/packages/cli/bin/market_scores.dart
+++ b/packages/cli/bin/market_scores.dart
@@ -1,4 +1,3 @@
-import 'package:cli/cache/market_price_snapshot.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/market_scores.dart';
 

--- a/packages/cli/bin/routing_plan.dart
+++ b/packages/cli/bin/routing_plan.dart
@@ -89,8 +89,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   } else if (argResults['fuel'] == 'false') {
     sellsFuel = (_) => false;
   } else if (argResults['fuel'] == 'cache') {
-    final marketListings = await db.marketListings.snapshotAll();
-    sellsFuel = defaultSellsFuel(marketListings);
+    sellsFuel = await defaultSellsFuel(db);
   } else {
     throw UnimplementedError();
   }

--- a/packages/cli/bin/routing_tests.dart
+++ b/packages/cli/bin/routing_tests.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/compare.dart';
 import 'package:equatable/equatable.dart';
@@ -261,7 +260,7 @@ void runTests(TestSuite suite, String path) {
   }
 
   final systemsCache = SystemsSnapshot(systems);
-  final systemConnectivity = SystemConnectivity.test({});
+  final systemConnectivity = SystemConnectivity.test(const {});
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systemsCache,
     systemConnectivity,

--- a/packages/cli/bin/routing_warp_test.dart
+++ b/packages/cli/bin/routing_warp_test.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/nav/navigation.dart';
@@ -44,11 +43,6 @@ Future<void> command(Database db, ArgResults argResults) async {
   // }
 
   final systemConnectivity = await loadSystemConnectivity(db);
-  // final routePlanner = RoutePlanner.fromSystemsCache(
-  //   systemsCache,
-  //   systemConnectivity,
-  //   sellsFuel: sellsFuel,
-  // );
 
   final shipyardShips = ShipyardShipCache(db);
   final ship = await shipyardShips.get(shipType);

--- a/packages/cli/bin/routing_warp_test.dart
+++ b/packages/cli/bin/routing_warp_test.dart
@@ -26,8 +26,7 @@ Future<void> command(Database db, ArgResults argResults) async {
 
   final agent = await db.getMyAgent();
   final systemsSnapshot = await db.systems.snapshotAllSystems();
-  final marketListings = await db.marketListings.snapshotAll();
-  final sellsFuel = defaultSellsFuel(marketListings);
+  final sellsFuel = await defaultSellsFuel(db);
   // final sellsFuel = defaultFuel;
   // bool sellsFuel(WaypointSymbol symbol) {
   //   return true;

--- a/packages/cli/bin/seeder_next_route.dart
+++ b/packages/cli/bin/seeder_next_route.dart
@@ -1,7 +1,5 @@
 import 'package:cli/behavior/seeder.dart';
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
-import 'package:cli/nav/navigation.dart';
 
 void main(List<String> args) async {
   await runOffline(args, command);
@@ -14,12 +12,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   final ships = await ShipSnapshot.load(db);
 
   // Find ones not in our main cluster.
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: await defaultSellsFuel(db),
-  );
+  final routePlanner = await defaultRoutePlanner(db);
 
   final explorer = ships.ships.firstWhere((s) => s.isExplorer);
   final behaviors = await BehaviorSnapshot.load(db);
@@ -30,7 +23,6 @@ Future<void> command(Database db, ArgResults argResults) async {
     behaviors,
     systemsCache,
     routePlanner,
-    systemConnectivity,
     explorer,
   );
   if (route == null) {

--- a/packages/cli/bin/seeder_next_route.dart
+++ b/packages/cli/bin/seeder_next_route.dart
@@ -9,7 +9,6 @@ void main(List<String> args) async {
 
 Future<void> command(Database db, ArgResults argResults) async {
   final agent = await db.getMyAgent();
-  final marketListings = await db.marketListings.snapshotAll();
 
   final systemsCache = await db.systems.snapshotAllSystems();
   final ships = await ShipSnapshot.load(db);
@@ -19,7 +18,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systemsCache,
     systemConnectivity,
-    sellsFuel: defaultSellsFuel(marketListings),
+    sellsFuel: await defaultSellsFuel(db),
   );
 
   final explorer = ships.ships.firstWhere((s) => s.isExplorer);

--- a/packages/cli/bin/shipyard_prices.dart
+++ b/packages/cli/bin/shipyard_prices.dart
@@ -27,7 +27,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   };
 
   for (final shipType in ShipType.values) {
-    final listings = shipyardListings.listingsWithShip(shipType);
+    final listings = shipyardListings.withShip(shipType);
     if (!showAll && listings.isEmpty) {
       continue;
     }

--- a/packages/cli/bin/shipyard_prices.dart
+++ b/packages/cli/bin/shipyard_prices.dart
@@ -1,6 +1,3 @@
-import 'package:cli/cache/shipyard_listing_snapshot.dart';
-import 'package:cli/cache/shipyard_price_snapshot.dart';
-import 'package:cli/cache/static_cache.dart';
 import 'package:cli/cli.dart';
 import 'package:cli_table/cli_table.dart';
 

--- a/packages/cli/bin/short_warps.dart
+++ b/packages/cli/bin/short_warps.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/nav/navigation.dart';
 import 'package:cli/nav/warp_pathing.dart';

--- a/packages/cli/bin/short_warps.dart
+++ b/packages/cli/bin/short_warps.dart
@@ -110,7 +110,7 @@ Future<void> command(Database db, ArgResults argResults) async {
       start: explorer.waypointSymbol,
       // Pick the waypoint closest to our current location?
       end: system.waypoints.first.symbol,
-      sellsFuel: defaultSellsFuel(marketListings),
+      sellsFuel: await defaultSellsFuel(db),
     );
     if (actions != null) {
       final plan = RoutePlan(

--- a/packages/cli/bin/simulate.dart
+++ b/packages/cli/bin/simulate.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';
 import 'package:cli/plan/mining.dart';
@@ -150,12 +149,7 @@ int shipPrice(ShipyardPriceSnapshot shipyardPrices, ShipType shipType) {
 Future<void> command(Database db, ArgResults argResults) async {
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
   final systemsCache = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systemsCache,
-    systemConnectivity,
-    sellsFuel: (_) => false,
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   final shipyardPrices = await ShipyardPriceSnapshot.load(db);
   final shipyardShips = await ShipyardShipCache(db).snapshot();
   final shipMounts = await ShipMountCache(db).snapshot();

--- a/packages/cli/bin/slots_charters.dart
+++ b/packages/cli/bin/slots_charters.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:collection/collection.dart';
 

--- a/packages/cli/bin/slots_traders.dart
+++ b/packages/cli/bin/slots_traders.dart
@@ -12,11 +12,10 @@ Future<void> command(Database db, ArgResults argResults) async {
   final systemConnectivity = await loadSystemConnectivity(db);
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
   final agent = await db.getMyAgent();
-  final marketListings = await db.marketListings.snapshotAll();
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systems,
     systemConnectivity,
-    sellsFuel: defaultSellsFuel(marketListings),
+    sellsFuel: await defaultSellsFuel(db),
   );
   final startSystem = agent!.headquarters.system;
   const shipType = ShipType.REFINING_FREIGHTER;

--- a/packages/cli/bin/slots_traders.dart
+++ b/packages/cli/bin/slots_traders.dart
@@ -1,22 +1,14 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';
-import 'package:cli/nav/navigation.dart';
 import 'package:cli/plan/trading.dart';
 import 'package:collection/collection.dart';
 
 Future<void> command(Database db, ArgResults argResults) async {
   // First need to figure out which systems are worth checking.
 
-  final systems = await db.systems.snapshotAllSystems();
-  final systemConnectivity = await loadSystemConnectivity(db);
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
   final agent = await db.getMyAgent();
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systems,
-    systemConnectivity,
-    sellsFuel: await defaultSellsFuel(db),
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   final startSystem = agent!.headquarters.system;
   const shipType = ShipType.REFINING_FREIGHTER;
 
@@ -33,7 +25,7 @@ Future<void> command(Database db, ArgResults argResults) async {
 
   // Find all trades available across all systems.
   final marketScan = scanReachableMarkets(
-    systemConnectivity,
+    routePlanner.systemConnectivity,
     marketPrices,
     // start system is just used for reachability.
     startSystem: startSystem,

--- a/packages/cli/bin/squads.dart
+++ b/packages/cli/bin/squads.dart
@@ -1,5 +1,3 @@
-import 'package:cli/cache/ship_snapshot.dart';
-import 'package:cli/cache/static_cache.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/ships.dart';

--- a/packages/cli/bin/static_cache_export.dart
+++ b/packages/cli/bin/static_cache_export.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:cli/cache/static_cache.dart';
 import 'package:cli/cli.dart';
 import 'package:file/local.dart';
 

--- a/packages/cli/bin/static_cache_import_ships.dart
+++ b/packages/cli/bin/static_cache_import_ships.dart
@@ -1,5 +1,3 @@
-import 'package:cli/cache/ship_snapshot.dart';
-import 'package:cli/cache/static_cache.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/ships.dart';
 

--- a/packages/cli/bin/static_cache_missing.dart
+++ b/packages/cli/bin/static_cache_missing.dart
@@ -1,4 +1,3 @@
-import 'package:cli/cache/static_cache.dart';
 import 'package:cli/cli.dart';
 
 void _printMissing<K extends Object, V extends Object>(

--- a/packages/cli/bin/system_routing.dart
+++ b/packages/cli/bin/system_routing.dart
@@ -11,13 +11,12 @@ Future<void> command(Database db, ArgResults argResults) async {
 
   final systems = await db.systems.snapshotAllSystems();
   final hqSystemSymbol = await myHqSystemSymbol(db);
-  final marketListings = await db.marketListings.snapshotAll();
   final shipyardListings = await ShipyardListingSnapshot.load(db);
   final systemConnectivity = await loadSystemConnectivity(db);
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systems,
     systemConnectivity,
-    sellsFuel: defaultSellsFuel(marketListings),
+    sellsFuel: await defaultSellsFuel(db),
   );
   final waypoints = systems.waypointsInSystem(hqSystemSymbol);
   final shipyardListing =

--- a/packages/cli/bin/system_routing.dart
+++ b/packages/cli/bin/system_routing.dart
@@ -1,6 +1,4 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
-import 'package:cli/nav/navigation.dart';
 import 'package:cli_table/cli_table.dart';
 import 'package:collection/collection.dart';
 
@@ -12,12 +10,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   final systems = await db.systems.snapshotAllSystems();
   final hqSystemSymbol = await myHqSystemSymbol(db);
   final shipyardListings = await ShipyardListingSnapshot.load(db);
-  final systemConnectivity = await loadSystemConnectivity(db);
-  final routePlanner = RoutePlanner.fromSystemsSnapshot(
-    systems,
-    systemConnectivity,
-    sellsFuel: await defaultSellsFuel(db),
-  );
+  final routePlanner = await defaultRoutePlanner(db);
   final waypoints = systems.waypointsInSystem(hqSystemSymbol);
   final shipyardListing =
       shipyardListings.listingsInSystem(hqSystemSymbol).first;

--- a/packages/cli/bin/system_routing.dart
+++ b/packages/cli/bin/system_routing.dart
@@ -12,8 +12,7 @@ Future<void> command(Database db, ArgResults argResults) async {
   final shipyardListings = await ShipyardListingSnapshot.load(db);
   final routePlanner = await defaultRoutePlanner(db);
   final waypoints = systems.waypointsInSystem(hqSystemSymbol);
-  final shipyardListing =
-      shipyardListings.listingsInSystem(hqSystemSymbol).first;
+  final shipyardListing = shipyardListings.inSystem(hqSystemSymbol).first;
   final shipyard = systems.waypoint(shipyardListing.waypointSymbol);
 
   const shipType = ShipType.LIGHT_HAULER;

--- a/packages/cli/bin/system_to_chart_next.dart
+++ b/packages/cli/bin/system_to_chart_next.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';

--- a/packages/cli/bin/system_watchers.dart
+++ b/packages/cli/bin/system_watchers.dart
@@ -1,5 +1,4 @@
 import 'package:cli/behavior/system_watcher.dart';
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/logic/printing.dart';
 import 'package:cli/nav/navigation.dart';

--- a/packages/cli/bin/systems_explored.dart
+++ b/packages/cli/bin/systems_explored.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli_table/cli_table.dart';
 import 'package:collection/collection.dart';

--- a/packages/cli/bin/systems_explored.dart
+++ b/packages/cli/bin/systems_explored.dart
@@ -64,9 +64,9 @@ Future<void> command(Database db, ArgResults argResults) async {
     table.add([
       systemSymbol.systemName,
       _typeName(system!.type),
-      marketListings.listingsInSystem(systemSymbol).length,
+      marketListings.countInSystem(systemSymbol),
       marketPrices.waypointSymbolsInSystem(systemSymbol).length,
-      shipyardListings.listingsInSystem(systemSymbol).length,
+      shipyardListings.countInSystem(systemSymbol),
       shipyardPrices.waypointSymbolsInSystem(systemSymbol).length,
       waypointCount,
       progressString(chartedOther.length, otherSymbols.length),

--- a/packages/cli/bin/systems_interesting.dart
+++ b/packages/cli/bin/systems_interesting.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 

--- a/packages/cli/bin/systems_nearby.dart
+++ b/packages/cli/bin/systems_nearby.dart
@@ -16,8 +16,7 @@ Future<void> command(Database db, ArgResults argResults) async {
     return;
   }
   for (final connectedSystemSymbol in connectedSystemSymbols) {
-    final marketCount =
-        marketListings.listingsInSystem(connectedSystemSymbol).length;
+    final marketCount = marketListings.countInSystem(connectedSystemSymbol);
     logger.info(
       '${connectedSystemSymbol.system.padRight(9)} $marketCount markets',
     );

--- a/packages/cli/bin/systems_to_warp_to.dart
+++ b/packages/cli/bin/systems_to_warp_to.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/net/auth.dart';
 import 'package:collection/collection.dart';

--- a/packages/cli/bin/waypoint_cache_ages.dart
+++ b/packages/cli/bin/waypoint_cache_ages.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli_table/cli_table.dart';
 

--- a/packages/cli/bin/waypoint_reachability.dart
+++ b/packages/cli/bin/waypoint_reachability.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/nav/waypoint_connectivity.dart';
 

--- a/packages/cli/lib/accounting/balance_sheet.dart
+++ b/packages/cli/lib/accounting/balance_sheet.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/plan/ships.dart';
 

--- a/packages/cli/lib/behavior/miner_hauler.dart
+++ b/packages/cli/lib/behavior/miner_hauler.dart
@@ -4,7 +4,6 @@
 
 import 'package:cli/behavior/job.dart';
 import 'package:cli/behavior/miner.dart';
-import 'package:cli/caches.dart';
 import 'package:cli/central_command.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/nav/navigation.dart';

--- a/packages/cli/lib/cache/shipyard_listing_snapshot.dart
+++ b/packages/cli/lib/cache/shipyard_listing_snapshot.dart
@@ -28,22 +28,24 @@ class ShipyardListingSnapshot {
   int get waypointCount => _listingBySymbol.keys.length;
 
   /// Fetch the ShipyardListings for the given SystemSymbol.
-  Iterable<ShipyardListing> listingsInSystem(SystemSymbol system) =>
+  Iterable<ShipyardListing> inSystem(SystemSymbol system) =>
       listings.where((l) => l.waypointSymbol.system == system);
 
+  /// Count the number of ShipyardListings in the given SystemSymbol.
+  int countInSystem(SystemSymbol system) => inSystem(system).length;
+
   /// The ShipyardListings which sell the given ship type.
-  Iterable<ShipyardListing> listingsWithShip(ShipType shipType) {
+  Iterable<ShipyardListing> withShip(ShipType shipType) {
     return listings.where((listing) => listing.hasShip(shipType));
   }
 
   /// Fetch the ShipyardListing for the given WaypointSymbol.
-  ShipyardListing? listingForSymbol(WaypointSymbol waypointSymbol) {
-    return _listingBySymbol[waypointSymbol];
-  }
+  ShipyardListing? at(WaypointSymbol waypointSymbol) =>
+      _listingBySymbol[waypointSymbol];
 
   /// Fetch the ShipyardListing for the given WaypointSymbol.
   ShipyardListing? operator [](WaypointSymbol waypointSymbol) =>
-      listingForSymbol(waypointSymbol);
+      at(waypointSymbol);
 
   /// Returns true if we know of a Shipyard with the given ShipType.
   bool knowOfShipyardWithShip(ShipType shipType) {

--- a/packages/cli/lib/caches.dart
+++ b/packages/cli/lib/caches.dart
@@ -66,7 +66,7 @@ class Caches {
   final MarketCache markets;
 
   /// The route planner.
-  final RoutePlanner routePlanner;
+  RoutePlanner routePlanner;
 
   /// Cache of static data from the server.
   final StaticCaches static;
@@ -101,11 +101,10 @@ class Caches {
       constructionSnapshot,
     );
     // TODO(eseidel): Find a way to avoid fetching market listings here?
-    final marketListings = await db.marketListings.snapshotAll();
     final routePlanner = RoutePlanner.fromSystemsSnapshot(
       systems,
       systemConnectivity,
-      sellsFuel: defaultSellsFuel(marketListings),
+      sellsFuel: await defaultSellsFuel(db),
     );
 
     // Make sure factions are loaded.
@@ -138,7 +137,11 @@ class Caches {
       await db.jumpGates.snapshotAll(),
       await db.construction.snapshotAllRecords(),
     );
-    routePlanner.clearRoutingCaches();
+    routePlanner = RoutePlanner.fromSystemsSnapshot(
+      systems,
+      systemConnectivity,
+      sellsFuel: await defaultSellsFuel(db),
+    );
   }
 }
 

--- a/packages/cli/lib/caches.dart
+++ b/packages/cli/lib/caches.dart
@@ -43,7 +43,6 @@ class Caches {
     required this.factions,
     required this.static,
     required this.systemConnectivity,
-    required this.jumpGates,
     required this.galaxy,
   });
 
@@ -62,10 +61,6 @@ class Caches {
 
   /// The cache of waypoints.
   final WaypointCache waypoints;
-
-  /// The cache of jump gates.
-  // TODO(eseidel): This needs to update when changes!
-  final JumpGateSnapshot jumpGates;
 
   /// The cache of markets.
   final MarketCache markets;
@@ -126,7 +121,6 @@ class Caches {
       routePlanner: routePlanner,
       factions: factions,
       systemConnectivity: systemConnectivity,
-      jumpGates: jumpGates,
       galaxy: galaxy,
     );
   }
@@ -141,7 +135,7 @@ class Caches {
     }
 
     systemConnectivity.updateFromJumpGates(
-      jumpGates,
+      await db.jumpGates.snapshotAll(),
       await db.construction.snapshotAllRecords(),
     );
     routePlanner.clearRoutingCaches();

--- a/packages/cli/lib/caches.dart
+++ b/packages/cli/lib/caches.dart
@@ -57,7 +57,7 @@ class Caches {
   SystemsSnapshot systems;
 
   /// The cache of system connectivity.
-  final SystemConnectivity systemConnectivity;
+  SystemConnectivity systemConnectivity;
 
   /// The cache of waypoints.
   final WaypointCache waypoints;
@@ -100,7 +100,6 @@ class Caches {
       jumpGates,
       constructionSnapshot,
     );
-    // TODO(eseidel): Find a way to avoid fetching market listings here?
     final routePlanner = RoutePlanner.fromSystemsSnapshot(
       systems,
       systemConnectivity,
@@ -133,9 +132,11 @@ class Caches {
       systems = await db.systems.snapshotAllSystems();
     }
 
-    systemConnectivity.updateFromJumpGates(
-      await db.jumpGates.snapshotAll(),
-      await db.construction.snapshotAllRecords(),
+    final jumpGateSnapshot = await db.jumpGates.snapshotAll();
+    final constructionSnapshot = await db.construction.snapshotAllRecords();
+    final systemConnectivity = SystemConnectivity.fromJumpGates(
+      jumpGateSnapshot,
+      constructionSnapshot,
     );
     routePlanner = RoutePlanner.fromSystemsSnapshot(
       systems,

--- a/packages/cli/lib/central_command.dart
+++ b/packages/cli/lib/central_command.dart
@@ -830,7 +830,7 @@ class CentralCommand {
     // TODO(eseidel): This should be a db query.
     final shipyardSymbol =
         shipyardListings
-            .listingsInSystem(systemSymbol)
+            .inSystem(systemSymbol)
             .firstWhereOrNull((s) => s.hasShip(shipType))
             ?.waypointSymbol;
     if (shipyardSymbol == null) {

--- a/packages/cli/lib/cli.dart
+++ b/packages/cli/lib/cli.dart
@@ -2,12 +2,14 @@ import 'package:args/args.dart';
 import 'package:cli/caches.dart';
 import 'package:cli/config.dart';
 import 'package:cli/logger.dart';
+import 'package:cli/nav/navigation.dart';
 import 'package:db/db.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped_deps/scoped_deps.dart';
 import 'package:types/types.dart';
 
 export 'package:args/args.dart';
+export 'package:cli/caches.dart';
 export 'package:cli/logger.dart';
 export 'package:db/db.dart';
 export 'package:file/file.dart';
@@ -107,4 +109,15 @@ Future<SystemConnectivity> loadSystemConnectivity(Database db) async {
     constructionSnapshot,
   );
   return systemConnectivity;
+}
+
+/// Load a RoutePlanner from the database.
+Future<RoutePlanner> defaultRoutePlanner(Database db) async {
+  final systems = await db.systems.snapshotAllSystems();
+  final systemConnectivity = await loadSystemConnectivity(db);
+  return RoutePlanner.fromSystemsSnapshot(
+    systems,
+    systemConnectivity,
+    sellsFuel: await defaultSellsFuel(db),
+  );
 }

--- a/packages/cli/lib/logic/idle_queue.dart
+++ b/packages/cli/lib/logic/idle_queue.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:cli/config.dart';
 import 'package:cli/net/queries.dart';

--- a/packages/cli/lib/nav/navigation.dart
+++ b/packages/cli/lib/nav/navigation.dart
@@ -39,10 +39,9 @@ extension ShipNavUtils on Ship {
 /// Returns a function which will return true if market at a given waypoint
 /// symbol is known to sell fuel and false if we either don't know or
 /// know it doesn't sell fuel.
-bool Function(WaypointSymbol) defaultSellsFuel(MarketListingSnapshot listings) {
-  return (WaypointSymbol symbol) {
-    return listings[symbol]?.allowsTradeOf(TradeSymbol.FUEL) ?? false;
-  };
+Future<bool Function(WaypointSymbol)> defaultSellsFuel(Database db) async {
+  final fuelMarkets = await db.marketListings.marketsSellingFuel();
+  return fuelMarkets.contains;
 }
 
 /// Begins a new navigation action for [ship] to [destinationSymbol].

--- a/packages/cli/lib/nav/route.dart
+++ b/packages/cli/lib/nav/route.dart
@@ -607,7 +607,7 @@ Future<ShipyardListing?> nearestShipyard(
   Ship ship,
 ) async {
   final start = ship.waypointSymbol;
-  final listings = shipyards.listingsInSystem(start.system);
+  final listings = shipyards.inSystem(start.system);
 
   // If not in this system.  Should list all shipyardListings.
   // Filter by ones which are reachable (e.g. if this ship can warp).

--- a/packages/cli/lib/nav/route.dart
+++ b/packages/cli/lib/nav/route.dart
@@ -380,12 +380,6 @@ class RoutePlanner {
   /// The connectivity used for this RoutePlanner.
   SystemConnectivity get systemConnectivity => _systemConnectivity;
 
-  /// Clear any cached routing data.  Called when jump gate availability changes
-  /// because a jump gate is constructed.
-  void clearRoutingCaches() {
-    _jumpCache.clear();
-  }
-
   RoutePlan? _planJump(
     ShipSpec shipSpec, {
     required WaypointSymbol start,

--- a/packages/cli/lib/nav/system_connectivity.dart
+++ b/packages/cli/lib/nav/system_connectivity.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:types/types.dart';
 
 typedef _ClusterId = int;
@@ -179,6 +180,8 @@ class _Connections {
 }
 
 /// Holds connectivity information between systems.
+/// Represents a snapshot of the connectivity at a point in time.
+@immutable
 class SystemConnectivity {
   /// Creates a new SystemConnectivity.
   SystemConnectivity._(this._connections)
@@ -203,20 +206,8 @@ class SystemConnectivity {
     return SystemConnectivity._(connections);
   }
 
-  // We could make SystemConnectivity immutable, but then we would need
-  // to be careful never to hold onto it.  For now making it internally
-  // mutable is easier.
-  _Connections _connections;
-  _Clusters _clusters;
-
-  /// Updates the SystemConnectivity from the given caches.
-  void updateFromJumpGates(
-    JumpGateSnapshot jumpGates,
-    ConstructionSnapshot constructionSnapshot,
-  ) {
-    _connections = _Connections.fromSnapshots(jumpGates, constructionSnapshot);
-    _clusters = _Clusters.fromConnections(_connections);
-  }
+  final _Connections _connections;
+  final _Clusters _clusters;
 
   /// Returns the number of systems reachable from [systemSymbol].
   int connectedSystemCount(SystemSymbol systemSymbol) =>

--- a/packages/cli/test/cache/caches_mock.dart
+++ b/packages/cli/test/cache/caches_mock.dart
@@ -4,8 +4,6 @@ import 'package:types/types.dart';
 
 class _MockEventCache extends Mock implements EventCache {}
 
-class _MockJumpGateSnapshot extends Mock implements JumpGateSnapshot {}
-
 class _MockMarketCache extends Mock implements MarketCache {}
 
 class _MockMarketPrices extends Mock implements MarketPriceSnapshot {}
@@ -83,7 +81,6 @@ Caches mockCaches() {
     factions: [],
     static: staticCaches,
     systemConnectivity: _MockSystemConnectivity(),
-    jumpGates: _MockJumpGateSnapshot(),
     galaxy: _MockGalaxyStats(),
   );
 }

--- a/packages/cli/test/cache/caches_test.dart
+++ b/packages/cli/test/cache/caches_test.dart
@@ -120,8 +120,9 @@ void main() {
     final marketListingStore = _MockMarketListingStore();
     when(() => db.marketListings).thenReturn(marketListingStore);
     when(
-      marketListingStore.snapshotAll,
-    ).thenAnswer((_) async => MarketListingSnapshot([]));
+      marketListingStore.marketsSellingFuel,
+    ).thenAnswer((_) async => <WaypointSymbol>{});
+
     when(db.allMarketPrices).thenAnswer((_) async => []);
     when(db.allShipyardListings).thenAnswer((_) async => []);
     when(db.allShipyardPrices).thenAnswer((_) async => []);
@@ -192,6 +193,12 @@ void main() {
     when(
       jumpGateStore.snapshotAll,
     ).thenAnswer((_) async => JumpGateSnapshot([]));
+
+    final marketListingStore = _MockMarketListingStore();
+    when(() => db.marketListings).thenReturn(marketListingStore);
+    when(
+      marketListingStore.marketsSellingFuel,
+    ).thenAnswer((_) async => <WaypointSymbol>{});
 
     final caches = Caches(
       marketPrices: _MockMarketPrices(),

--- a/packages/cli/test/cache/caches_test.dart
+++ b/packages/cli/test/cache/caches_test.dart
@@ -21,8 +21,6 @@ class _MockFleetApi extends Mock implements FleetApi {}
 
 class _MockGlobalApi extends Mock implements GlobalApi {}
 
-class _MockJumpGateSnapshot extends Mock implements JumpGateSnapshot {}
-
 class _MockJumpGateStore extends Mock implements JumpGateStore {}
 
 class _MockLogger extends Mock implements Logger {}
@@ -189,6 +187,12 @@ void main() {
       constructionStore.snapshotAllRecords,
     ).thenAnswer((_) async => ConstructionSnapshot([]));
 
+    final jumpGateStore = _MockJumpGateStore();
+    when(() => db.jumpGates).thenReturn(jumpGateStore);
+    when(
+      jumpGateStore.snapshotAll,
+    ).thenAnswer((_) async => JumpGateSnapshot([]));
+
     final caches = Caches(
       marketPrices: _MockMarketPrices(),
       systems: SystemsSnapshot([]),
@@ -197,7 +201,6 @@ void main() {
       routePlanner: _MockRoutePlanner(),
       static: _MockStaticCaches(),
       systemConnectivity: _MockSystemConnectivity(),
-      jumpGates: _MockJumpGateSnapshot(),
       galaxy: const GalaxyStats(systemCount: 2, waypointCount: 2),
       factions: [],
     );

--- a/packages/cli/test/cache/caches_test.dart
+++ b/packages/cli/test/cache/caches_test.dart
@@ -1,4 +1,3 @@
-import 'package:cli/caches.dart';
 import 'package:cli/cli.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -235,6 +234,9 @@ void main() {
     expect(caches.systems.waypointsCount, 2);
     verify(() => logger.info('Systems Snapshot is incomplete, reloading.'));
     verify(() => db.systems.snapshotAllSystems()).called(1);
+    verify(() => db.jumpGates.snapshotAll()).called(1);
+    verify(() => db.construction.snapshotAllRecords()).called(1);
+    verify(() => db.marketListings.marketsSellingFuel()).called(1);
 
     await caches.updateRoutingCaches(db);
     // If we've already cached the systems, we don't need to snapshot them again

--- a/packages/cli/test/cache/shipyard_listing_snapshot_test.dart
+++ b/packages/cli/test/cache/shipyard_listing_snapshot_test.dart
@@ -1,0 +1,64 @@
+import 'package:cli/cache/shipyard_listing_snapshot.dart';
+import 'package:test/test.dart';
+import 'package:types/types.dart';
+
+void main() {
+  group('ShipyardListingSnapshot', () {
+    test('withShip', () {
+      final snapshot = ShipyardListingSnapshot([
+        ShipyardListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-C'),
+          shipTypes: const {ShipType.ORE_HOUND},
+        ),
+      ]);
+      expect(snapshot.withShip(ShipType.ORE_HOUND).length, 1);
+    });
+
+    test('knowOfShipyardWithShip', () {
+      final snapshot = ShipyardListingSnapshot([
+        ShipyardListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-C'),
+          shipTypes: const {ShipType.ORE_HOUND},
+        ),
+      ]);
+      expect(snapshot.knowOfShipyardWithShip(ShipType.ORE_HOUND), isTrue);
+      expect(
+        snapshot.knowOfShipyardWithShip(ShipType.COMMAND_FRIGATE),
+        isFalse,
+      );
+    });
+
+    test('at', () {
+      final waypointSymbol = WaypointSymbol.fromString('A-B-C');
+      final snapshot = ShipyardListingSnapshot([
+        ShipyardListing(
+          waypointSymbol: waypointSymbol,
+          shipTypes: const {ShipType.ORE_HOUND},
+        ),
+      ]);
+      expect(snapshot.at(waypointSymbol), isNotNull);
+      expect(snapshot[waypointSymbol], isNotNull);
+      expect(snapshot.at(WaypointSymbol.fromString('A-B-D')), isNull);
+    });
+
+    test('inSystem', () {
+      final snapshot = ShipyardListingSnapshot([
+        ShipyardListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-C'),
+          shipTypes: const {ShipType.ORE_HOUND},
+        ),
+      ]);
+      expect(snapshot.inSystem(SystemSymbol.fromString('A-B')).length, 1);
+    });
+
+    test('countInSystem', () {
+      final snapshot = ShipyardListingSnapshot([
+        ShipyardListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-C'),
+          shipTypes: const {ShipType.ORE_HOUND},
+        ),
+      ]);
+      expect(snapshot.countInSystem(SystemSymbol.fromString('A-B')), 1);
+    });
+  });
+}

--- a/packages/db/lib/src/queries/market_listing.dart
+++ b/packages/db/lib/src/queries/market_listing.dart
@@ -81,6 +81,16 @@ Query knowOfMarketWhichTradesQuery(TradeSymbol tradeSymbol) => Query(
   parameters: {'tradeSymbol': tradeSymbol.toJson()},
 );
 
+/// Query to find all markets which sell fuel.
+Query marketsWhichTradeFuelQuery() => Query(
+  '''
+      SELECT symbol FROM market_listing_
+      WHERE @tradeSymbol = ANY(imports) OR @tradeSymbol = ANY(exchange) OR
+        @tradeSymbol = ANY(exports)
+      ''',
+  parameters: {'tradeSymbol': TradeSymbol.FUEL.toJson()},
+);
+
 /// Build a column map from a market listing.
 Map<String, dynamic> marketListingToColumnMap(MarketListing marketListing) => {
   'symbol': marketListing.waypointSymbol.toJson(),

--- a/packages/db/lib/src/stores/market_listing_store.dart
+++ b/packages/db/lib/src/stores/market_listing_store.dart
@@ -33,6 +33,13 @@ class MarketListingStore {
     return MarketListingSnapshot(listings);
   }
 
+  /// Get all market listings which sell fuel.
+  Future<Set<WaypointSymbol>> marketsSellingFuel() async {
+    final query = marketsWhichTradeFuelQuery();
+    final list = await _db.queryMany(query, marketListingSymbolFromColumnMap);
+    return list.toSet();
+  }
+
   /// Get all market listings within a system.
   Future<Iterable<MarketListing>> inSystem(SystemSymbol system) async {
     final query = marketListingsInSystemQuery(system);

--- a/packages/db/test/stores/market_listing_store_test.dart
+++ b/packages/db/test/stores/market_listing_store_test.dart
@@ -161,6 +161,27 @@ void main() {
         final otherSystemSnapshot = await listings.snapshotSystem(otherSystem);
         expect(otherSystemSnapshot.listings.length, equals(0));
       });
+
+      test('markets which trade fuel', () async {
+        final listings = db.marketListings;
+        final fuelListing1 = MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('X1-A-1'),
+          imports: const {TradeSymbol.FUEL},
+        );
+        final fuelListing2 = MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('X1-B-2'),
+          exchange: const {TradeSymbol.FUEL},
+        );
+        final fuelListing3 = MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('X1-C-3'),
+          exports: const {TradeSymbol.FUEL},
+        );
+        await listings.upsert(fuelListing1);
+        await listings.upsert(fuelListing2);
+        await listings.upsert(fuelListing3);
+        final fuelMarkets = await listings.marketsSellingFuel();
+        expect(fuelMarkets.length, equals(3));
+      });
     });
   });
 }

--- a/packages/server/routes/api/deals/nearby.dart
+++ b/packages/server/routes/api/deals/nearby.dart
@@ -29,7 +29,7 @@ Future<api.DealsNearbyResponse> dealsNearby({
   final routePlanner = RoutePlanner.fromSystemsSnapshot(
     systems,
     systemConnectivity,
-    sellsFuel: defaultSellsFuel(marketListings),
+    sellsFuel: await defaultSellsFuel(db),
   );
   final marketPrices = await MarketPriceSnapshot.loadAll(db);
 

--- a/packages/types/lib/src/snapshot/market_listing_snapshot.dart
+++ b/packages/types/lib/src/snapshot/market_listing_snapshot.dart
@@ -17,8 +17,12 @@ class MarketListingSnapshot {
   Iterable<MarketListing> get listings => _listingBySymbol.values;
 
   /// Fetch the MarketListings for the given SystemSymbol.
-  Iterable<MarketListing> listingsInSystem(SystemSymbol systemSymbol) =>
+  Iterable<MarketListing> _inSystem(SystemSymbol systemSymbol) =>
       listings.where((l) => l.waypointSymbol.system == systemSymbol);
+
+  /// Count the number of MarketListings in the given SystemSymbol.
+  int countInSystem(SystemSymbol systemSymbol) =>
+      _inSystem(systemSymbol).length;
 
   /// Fetch the MarketListing for the given WaypointSymbol.
   MarketListing? operator [](WaypointSymbol waypointSymbol) =>

--- a/packages/types/lib/src/snapshot/market_listing_snapshot.dart
+++ b/packages/types/lib/src/snapshot/market_listing_snapshot.dart
@@ -38,6 +38,19 @@ class MarketListingSnapshot {
         .toSet();
   }
 
+  /// Returns all MarketListings which export the given TradeSymbol in
+  /// the given SystemSymbol.
+  /// Unlike the MarketListingStore version which returns WaypointSymbols.
+  Iterable<MarketListing> whichExportsInSystem(
+    SystemSymbol system,
+    TradeSymbol tradeSymbol,
+  ) {
+    return listings.where(
+      (l) =>
+          l.waypointSymbol.system == system && l.exports.contains(tradeSymbol),
+    );
+  }
+
   /// Returns true if we know of a market which trades the given TradeSymbol.
   bool knowOfMarketWhichTrades(TradeSymbol tradeSymbol) =>
       listings.any((l) => l.allowsTradeOf(tradeSymbol));

--- a/packages/types/test/src/snapshot/market_listing_snapshot_test.dart
+++ b/packages/types/test/src/snapshot/market_listing_snapshot_test.dart
@@ -1,0 +1,66 @@
+import 'package:test/test.dart';
+import 'package:types/types.dart';
+
+void main() {
+  group('MarketListingSnapshot', () {
+    test('whichExportsInSystem', () {
+      const tradeSymbol = TradeSymbol.DIAMONDS;
+      final waypointSymbol = WaypointSymbol.fromString('A-B-C');
+      final marketListing = MarketListing(
+        waypointSymbol: waypointSymbol,
+        exports: const {tradeSymbol},
+      );
+      final marketListingSnapshot = MarketListingSnapshot([marketListing]);
+      final result = marketListingSnapshot.whichExportsInSystem(
+        waypointSymbol.system,
+        tradeSymbol,
+      );
+      expect(result, isNotEmpty);
+    });
+
+    test('countInSystem', () {
+      const tradeSymbol = TradeSymbol.DIAMONDS;
+      final waypointSymbol = WaypointSymbol.fromString('A-B-C');
+      final marketListing = MarketListing(
+        waypointSymbol: waypointSymbol,
+        exports: const {tradeSymbol},
+      );
+      final marketListingSnapshot = MarketListingSnapshot([marketListing]);
+      final result = marketListingSnapshot.countInSystem(waypointSymbol.system);
+      expect(result, 1);
+    });
+
+    test('knowOfMarketWhichTrades', () {
+      const tradeSymbol = TradeSymbol.DIAMONDS;
+      final waypointSymbol = WaypointSymbol.fromString('A-B-C');
+      final marketListing = MarketListing(
+        waypointSymbol: waypointSymbol,
+        exports: const {tradeSymbol},
+      );
+      final marketListingSnapshot = MarketListingSnapshot([marketListing]);
+      final result = marketListingSnapshot.knowOfMarketWhichTrades(tradeSymbol);
+      expect(result, isTrue);
+    });
+
+    test('systemsWithAtLeastNMarkets', () {
+      const tradeSymbol = TradeSymbol.DIAMONDS;
+      final marketListings = [
+        MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('A-A-C'),
+          exports: const {tradeSymbol},
+        ),
+        MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-D'),
+          exports: const {tradeSymbol},
+        ),
+        MarketListing(
+          waypointSymbol: WaypointSymbol.fromString('A-B-E'),
+          exports: const {tradeSymbol},
+        ),
+      ];
+      final marketListingSnapshot = MarketListingSnapshot(marketListings);
+      final result = marketListingSnapshot.systemsWithAtLeastNMarkets(2);
+      expect(result, equals([SystemSymbol.fromString('A-B')]));
+    });
+  });
+}


### PR DESCRIPTION
Our routing caches were not updating correctly in two ways:
1. it was not pulling a new jumpgate snapshot when rebuilding system reachability.
2. was not updating sellsFuel function, so new markets which sell fuel could not be routed to.