### PR TITLE
fix: contract queries fail to find active contracts

### DIFF
--- a/packages/db/lib/migrations.dart
+++ b/packages/db/lib/migrations.dart
@@ -19,6 +19,7 @@ import 'package:db/migrations/18_config.dart';
 import 'package:db/migrations/19_static_data.dart';
 import 'package:db/migrations/20_system_record.dart';
 import 'package:db/migrations/21_system_waypoint.dart';
+import 'package:db/migrations/22_contract_deadline.dart';
 import 'package:db/src/migration.dart';
 
 /// All migrations in order.
@@ -44,6 +45,7 @@ final allMigrations = validateMigrations(<Migration>[
   CreateStaticDataMigration(),
   CreateSystemRecordMigration(),
   CreateSystemWaypointMigration(),
+  ContractDeadlineMigration(),
 ]);
 
 /// Validates that:

--- a/packages/db/lib/migrations/22_contract_deadline.dart
+++ b/packages/db/lib/migrations/22_contract_deadline.dart
@@ -1,0 +1,17 @@
+import 'package:db/src/migration.dart';
+
+/// Migration to create the system_waypoint_ table for storing system waypoints.
+class ContractDeadlineMigration implements Migration {
+  @override
+  int get version => 22;
+
+  @override
+  String get up => '''
+    ALTER TABLE contract_ ADD COLUMN deadline_to_complete timestamp;
+  ''';
+
+  @override
+  String get down => '''
+    ALTER TABLE contract_ DROP COLUMN deadline_to_complete;
+  ''';
+}

--- a/packages/db/lib/src/queries/contract.dart
+++ b/packages/db/lib/src/queries/contract.dart
@@ -7,9 +7,9 @@ Query allContractsQuery() => const Query('SELECT * FROM contract_');
 /// Upsert a contract.
 Query upsertContractQuery(Contract contract) {
   return Query(parameters: contractToColumnMap(contract), '''
-    INSERT INTO contract_ (id, json, accepted, fulfilled, deadline_to_accept)
-    VALUES (@id, @json, @accepted, @fulfilled, @deadline_to_accept)
-    ON CONFLICT (id) DO UPDATE SET json = @json, accepted = @accepted, fulfilled = @fulfilled, deadline_to_accept = @deadline_to_accept
+    INSERT INTO contract_ (id, json, accepted, fulfilled, deadline_to_accept, deadline_to_complete)
+    VALUES (@id, @json, @accepted, @fulfilled, @deadline_to_accept, @deadline_to_complete)
+    ON CONFLICT (id) DO UPDATE SET json = @json, accepted = @accepted, fulfilled = @fulfilled, deadline_to_accept = @deadline_to_accept, deadline_to_complete = @deadline_to_complete
     ''');
 }
 
@@ -22,10 +22,11 @@ Query contractByIdQuery(String id) {
 }
 
 /// Get all contracts which are !fulfilled and expiration date is in the future.
+/// Both accepted and unaccepted contracts are included.
 Query activeContractsQuery(DateTime now) {
   return Query(
     'SELECT * FROM contract_ '
-    "WHERE fulfilled = 'false' AND deadline_to_accept > @now",
+    'WHERE fulfilled = FALSE AND deadline_to_complete > @now',
     parameters: {'now': now},
   );
 }
@@ -34,7 +35,7 @@ Query activeContractsQuery(DateTime now) {
 Query unacceptedContractsQuery(DateTime now) {
   return Query(
     'SELECT * FROM contract_ '
-    "WHERE accepted = 'false' AND deadline_to_accept > @now",
+    'WHERE accepted = FALSE AND deadline_to_accept > @now',
     parameters: {'now': now},
   );
 }
@@ -55,5 +56,6 @@ Map<String, dynamic> contractToColumnMap(Contract contract) {
     'accepted': contract.accepted,
     'fulfilled': contract.fulfilled,
     'deadline_to_accept': contract.deadlineToAccept,
+    'deadline_to_complete': contract.terms.deadline,
   };
 }

--- a/packages/db/lib/src/queries/contract.dart
+++ b/packages/db/lib/src/queries/contract.dart
@@ -23,10 +23,13 @@ Query contractByIdQuery(String id) {
 
 /// Get all contracts which are !fulfilled and expiration date is in the future.
 /// Both accepted and unaccepted contracts are included.
+/// Expired is defined differently for accepted and unaccepted contracts.
 Query activeContractsQuery(DateTime now) {
   return Query(
     'SELECT * FROM contract_ '
-    'WHERE fulfilled = FALSE AND deadline_to_complete > @now',
+    'WHERE fulfilled = FALSE '
+    'AND ((accepted = TRUE AND deadline_to_complete > @now) '
+    'OR (accepted = FALSE AND deadline_to_accept > @now))',
     parameters: {'now': now},
   );
 }

--- a/packages/db/test/stores/contract_store_test.dart
+++ b/packages/db/test/stores/contract_store_test.dart
@@ -13,24 +13,71 @@ void main() {
       );
       await db.migrateToLatestSchema();
 
-      final terms = ContractTerms(
-        deadline: DateTime.now(),
-        payment: ContractPayment(onAccepted: 100, onFulfilled: 100),
-      );
-
-      final contract = Contract.test(
-        id: 'foo',
-        terms: terms,
-        accepted: false,
-        fulfilled: false,
-      );
-
       final now = DateTime.timestamp();
-      final expired = Contract.test(
-        id: 'expired',
-        terms: terms,
+
+      const faction = 'faction';
+      const type = ContractTypeEnum.PROCUREMENT;
+
+      // unaccepted, not active.
+      final unaccepted = Contract(
+        id: 'unaccepted',
+        factionSymbol: faction,
+        type: type,
+        terms: ContractTerms(
+          deadline: now.add(const Duration(days: 1)),
+          payment: ContractPayment(onAccepted: 100, onFulfilled: 100),
+        ),
         accepted: false,
         fulfilled: false,
+        timestamp: now,
+        deadlineToAccept: now.add(const Duration(days: 1)),
+      );
+
+      // expired, not unaccepted, not active.
+      final expired = Contract(
+        id: 'expired',
+        factionSymbol: faction,
+        type: type,
+        terms: ContractTerms(
+          // Out of time, but not complete.
+          deadline: now.add(const Duration(days: 1)),
+          payment: ContractPayment(onAccepted: 100, onFulfilled: 100),
+        ),
+        accepted: false,
+        fulfilled: false,
+        timestamp: now,
+        // We could have accepted it if we had not already.
+        deadlineToAccept: now.subtract(const Duration(days: 1)),
+      );
+
+      /// accepted, active, not fulfilled.
+      final acceptedPastDeadline = Contract(
+        id: 'acceptedPastDeadline',
+        factionSymbol: faction,
+        type: type,
+        terms: ContractTerms(
+          // Not complete, but not out of time yet.
+          deadline: now.add(const Duration(days: 1)),
+          payment: ContractPayment(onAccepted: 100, onFulfilled: 100),
+        ),
+        accepted: true,
+        fulfilled: false,
+        timestamp: now,
+        // But we could no longer accept it if we had not already.
+        deadlineToAccept: now.subtract(const Duration(days: 1)),
+      );
+
+      /// accepted, fulfilled (thus not active), not expired.
+      final fullfilled = Contract(
+        id: 'fullfilled',
+        factionSymbol: faction,
+        type: type,
+        terms: ContractTerms(
+          deadline: now.add(const Duration(days: 1)),
+          payment: ContractPayment(onAccepted: 100, onFulfilled: 100),
+        ),
+        accepted: true,
+        fulfilled: true,
         timestamp: now,
         deadlineToAccept: now.subtract(const Duration(days: 1)),
       );
@@ -38,24 +85,32 @@ void main() {
       expect(await db.contracts.unaccepted(), isEmpty);
       expect(await db.contracts.active(), isEmpty);
 
-      await db.contracts.upsert(contract);
+      await db.contracts.upsert(unaccepted);
       await db.contracts.upsert(expired);
-
+      await db.contracts.upsert(acceptedPastDeadline);
+      await db.contracts.upsert(fullfilled);
       // Contract does not implement equals, so we check the id.
-      expect((await db.contracts.get(contract.id))!.id, equals(contract.id));
+      expect(
+        (await db.contracts.get(unaccepted.id))!.id,
+        equals(unaccepted.id),
+      );
 
       // Expired shows up in all, but not in unaccepted or active.
-      expect(await db.contracts.all(), hasLength(2));
+      expect(await db.contracts.all(), hasLength(4));
       expect(await db.contracts.unaccepted(), hasLength(1));
-      expect(await db.contracts.active(), hasLength(1));
+      final active = await db.contracts.active();
+      for (final c in active) {
+        print(c.toJson());
+      }
+      expect(active, hasLength(1));
 
-      contract.accepted = true;
-      await db.contracts.upsert(contract);
+      unaccepted.accepted = true;
+      await db.contracts.upsert(unaccepted);
       expect(await db.contracts.unaccepted(), isEmpty);
       expect(await db.contracts.active(), isNotEmpty);
 
-      contract.fulfilled = true;
-      await db.contracts.upsert(contract);
+      unaccepted.fulfilled = true;
+      await db.contracts.upsert(unaccepted);
       expect(await db.contracts.unaccepted(), isEmpty);
       expect(await db.contracts.active(), isEmpty);
     });

--- a/packages/db/test/stores/contract_store_test.dart
+++ b/packages/db/test/stores/contract_store_test.dart
@@ -83,8 +83,8 @@ void main() {
       );
 
       /// accepted, fulfilled (thus not active), not expired.
-      final fullfilled = Contract(
-        id: 'fullfilled',
+      final fulfilled = Contract(
+        id: 'fulfilled',
         factionSymbol: faction,
         type: type,
         terms: ContractTerms(
@@ -104,7 +104,7 @@ void main() {
       await db.contracts.upsert(expiredBeforeAccept);
       await db.contracts.upsert(expiredAfterAccept);
       await db.contracts.upsert(acceptedPastDeadline);
-      await db.contracts.upsert(fullfilled);
+      await db.contracts.upsert(fulfilled);
       // Contract does not implement equals, so we check the id.
       expect(
         (await db.contracts.get(unaccepted.id))!.id,

--- a/packages/db/test/stores/contract_store_test.dart
+++ b/packages/db/test/stores/contract_store_test.dart
@@ -65,7 +65,7 @@ void main() {
         deadlineToAccept: now.subtract(const Duration(days: 1)),
       );
 
-      /// Accepted, past acceptence deadline. Active, not yet fulfilled.
+      /// Accepted, past acceptance deadline. Active, not yet fulfilled.
       final acceptedPastDeadline = Contract(
         id: 'acceptedPastDeadline',
         factionSymbol: faction,

--- a/packages/types/lib/src/contract.dart
+++ b/packages/types/lib/src/contract.dart
@@ -134,8 +134,6 @@ class Contract {
     );
   }
 
-  // bool needsItem(String tradeSymbol) => goodNeeded(tradeSymbol) != null;
-
   /// Returns the ContractDeliverGood for the given trade good symbol or null if
   /// the contract doesn't need that good.
   openapi.ContractDeliverGood? goodNeeded(openapi.TradeSymbol tradeSymbol) {


### PR DESCRIPTION
My previous change fixed contract queries to respect deadlines, but only partially.
This is the full fix.