### PR TITLE
fix: work around 500 errors from server when calling refuel

### DIFF
--- a/packages/cli/lib/net/direct.dart
+++ b/packages/cli/lib/net/direct.dart
@@ -248,7 +248,10 @@ Future<RefuelShip200ResponseData> refuelShip(
   // We used to have logic to avoid filling to full, but our route planner
   // doesn't account for non-full tanks, so for now we just always
   // refill to full.
-  final request = fromCargo ? RefuelShipRequest(fromCargo: fromCargo) : null;
+  // Always send an explicit request to avoid the server being confused
+  // about an empty body with application/json as content type.
+  // https://discord.com/channels/792864705139048469/1371193425348526100
+  final request = RefuelShipRequest(fromCargo: fromCargo);
   final responseWrapper = await api.fleet.refuelShip(
     ship.symbol.symbol,
     refuelShipRequest: request,

--- a/packages/cli/lib/net/direct.dart
+++ b/packages/cli/lib/net/direct.dart
@@ -250,8 +250,13 @@ Future<RefuelShip200ResponseData> refuelShip(
   // refill to full.
   // Always send an explicit request to avoid the server being confused
   // about an empty body with application/json as content type.
+  // Remove this once the server is fixed.
   // https://discord.com/channels/792864705139048469/1371193425348526100
-  final request = RefuelShipRequest(fromCargo: fromCargo);
+  final fullRefuel = RefuelShipRequest(
+    units: ship.fuel.capacity - ship.fuel.current,
+  );
+  final request =
+      fromCargo ? RefuelShipRequest(fromCargo: fromCargo) : fullRefuel;
   final responseWrapper = await api.fleet.refuelShip(
     ship.symbol.symbol,
     refuelShipRequest: request,

--- a/packages/cli/lib/net/direct.dart
+++ b/packages/cli/lib/net/direct.dart
@@ -252,11 +252,10 @@ Future<RefuelShip200ResponseData> refuelShip(
   // about an empty body with application/json as content type.
   // Remove this once the server is fixed.
   // https://discord.com/channels/792864705139048469/1371193425348526100
-  final fullRefuel = RefuelShipRequest(
-    units: ship.fuel.capacity - ship.fuel.current,
-  );
-  final request =
-      fromCargo ? RefuelShipRequest(fromCargo: fromCargo) : fullRefuel;
+  // and
+  // https://discord.com/channels/792864705139048469/1373743083799187558
+  final refuelAmount = ship.fuel.capacity - ship.fuel.current;
+  final request = RefuelShipRequest(fromCargo: fromCargo, units: refuelAmount);
   final responseWrapper = await api.fleet.refuelShip(
     ship.symbol.symbol,
     refuelShipRequest: request,

--- a/packages/cli/test/net/actions_test.dart
+++ b/packages/cli/test/net/actions_test.dart
@@ -423,7 +423,12 @@ void main() {
         medianFuelPurchasePrice: 100,
       ),
     );
-    verify(() => fleetApi.refuelShip(shipSymbol.symbol)).called(1);
+    verify(
+      () => fleetApi.refuelShip(
+        shipSymbol.symbol,
+        refuelShipRequest: RefuelShipRequest(),
+      ),
+    ).called(1);
     verifyNever(
       () => fleetApi.patchShipNav(
         any(),
@@ -504,7 +509,12 @@ void main() {
         medianFuelPurchasePrice: 100,
       ),
     );
-    verify(() => fleetApi.refuelShip(shipSymbol.symbol)).called(1);
+    verify(
+      () => fleetApi.refuelShip(
+        shipSymbol.symbol,
+        refuelShipRequest: RefuelShipRequest(),
+      ),
+    ).called(1);
 
     // It does refuel if our recent trip data has a large trip
     clearInteractions(fleetApi);
@@ -527,7 +537,12 @@ void main() {
         medianFuelPurchasePrice: 100,
       ),
     );
-    verify(() => fleetApi.refuelShip(shipSymbol.symbol)).called(1);
+    verify(
+      () => fleetApi.refuelShip(
+        shipSymbol.symbol,
+        refuelShipRequest: RefuelShipRequest(),
+      ),
+    ).called(1);
 
     // It will also refuel if our fuel is < 50% of capacity
     clearInteractions(fleetApi);
@@ -550,7 +565,12 @@ void main() {
         medianFuelPurchasePrice: 100,
       ),
     );
-    verify(() => fleetApi.refuelShip(shipSymbol.symbol)).called(1);
+    verify(
+      () => fleetApi.refuelShip(
+        shipSymbol.symbol,
+        refuelShipRequest: RefuelShipRequest(),
+      ),
+    ).called(1);
   });
 
   test('sellAllCargoAndLog', () async {

--- a/packages/cli/test/net/actions_test.dart
+++ b/packages/cli/test/net/actions_test.dart
@@ -423,10 +423,11 @@ void main() {
         medianFuelPurchasePrice: 100,
       ),
     );
+    registerFallbackValue(RefuelShipRequest(units: 336));
     verify(
       () => fleetApi.refuelShip(
         shipSymbol.symbol,
-        refuelShipRequest: RefuelShipRequest(),
+        refuelShipRequest: any(named: 'refuelShipRequest'),
       ),
     ).called(1);
     verifyNever(
@@ -512,7 +513,7 @@ void main() {
     verify(
       () => fleetApi.refuelShip(
         shipSymbol.symbol,
-        refuelShipRequest: RefuelShipRequest(),
+        refuelShipRequest: any(named: 'refuelShipRequest'),
       ),
     ).called(1);
 
@@ -540,7 +541,7 @@ void main() {
     verify(
       () => fleetApi.refuelShip(
         shipSymbol.symbol,
-        refuelShipRequest: RefuelShipRequest(),
+        refuelShipRequest: any(named: 'refuelShipRequest'),
       ),
     ).called(1);
 
@@ -568,7 +569,7 @@ void main() {
     verify(
       () => fleetApi.refuelShip(
         shipSymbol.symbol,
-        refuelShipRequest: RefuelShipRequest(),
+        refuelShipRequest: any(named: 'refuelShipRequest'),
       ),
     ).called(1);
   });

--- a/packages/openapi/lib/api_client.dart
+++ b/packages/openapi/lib/api_client.dart
@@ -98,23 +98,11 @@ class ApiClient {
 
       switch (method) {
         case 'POST':
-          {
-            if (nullableHeaderParams?['Content-Type'] == 'application/json' &&
-                json.encode(msgBody).isEmpty) {
-              final headers = {...?nullableHeaderParams, 'Content-Length': '0'};
-              return await _client.post(
-                uri,
-                headers: headers,
-                body: msgBody,
-              );
-            } else {
-              return await _client.post(
-                uri,
-                headers: nullableHeaderParams,
-                body: msgBody,
-              );
-            }
-          }
+          return await _client.post(
+            uri,
+            headers: nullableHeaderParams,
+            body: msgBody,
+          );
         case 'PUT':
           return await _client.put(
             uri,


### PR DESCRIPTION
Server throws a 500 if you send an empty body with an "application/json" content type.
This is a bug, they'll fix it at some point.

For now, work around this by always including a body in refuel requests, even when
we want a full refuel.

Also remove a previous attempt to hack around this server bug.