### PR TITLE
feat: support operator== and hashCode and fix jsonName vs. dartName

### DIFF
--- a/packages/gen/examples/spacetraders/lib/model/accept_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/accept_contract200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/accept_contract200_response_data.dart';
 
+@immutable
 class AcceptContract200Response {
-  AcceptContract200Response({required this.data});
+  const AcceptContract200Response({required this.data});
 
   factory AcceptContract200Response.fromJson(Map<String, dynamic> json) {
     return AcceptContract200Response(

--- a/packages/gen/examples/spacetraders/lib/model/accept_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/accept_contract200_response.dart
@@ -25,4 +25,13 @@ class AcceptContract200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AcceptContract200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/accept_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/accept_contract200_response_data.dart
@@ -1,8 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/contract.dart';
 
+@immutable
 class AcceptContract200ResponseData {
-  AcceptContract200ResponseData({required this.contract, required this.agent});
+  const AcceptContract200ResponseData({
+    required this.contract,
+    required this.agent,
+  });
 
   factory AcceptContract200ResponseData.fromJson(Map<String, dynamic> json) {
     return AcceptContract200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/accept_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/accept_contract200_response_data.dart
@@ -28,4 +28,15 @@ class AcceptContract200ResponseData {
   Map<String, dynamic> toJson() {
     return {'contract': contract.toJson(), 'agent': agent.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(contract, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AcceptContract200ResponseData &&
+        contract == other.contract &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/agent.dart
+++ b/packages/gen/examples/spacetraders/lib/model/agent.dart
@@ -45,4 +45,26 @@ class Agent {
       'shipCount': shipCount,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    accountId,
+    symbol,
+    headquarters,
+    credits,
+    startingFaction,
+    shipCount,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Agent &&
+        accountId == other.accountId &&
+        symbol == other.symbol &&
+        headquarters == other.headquarters &&
+        credits == other.credits &&
+        startingFaction == other.startingFaction &&
+        shipCount == other.shipCount;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/agent.dart
+++ b/packages/gen/examples/spacetraders/lib/model/agent.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class Agent {
-  Agent({
+  const Agent({
     required this.accountId,
     required this.symbol,
     required this.headquarters,

--- a/packages/gen/examples/spacetraders/lib/model/agent_event.dart
+++ b/packages/gen/examples/spacetraders/lib/model/agent_event.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class AgentEvent {
-  AgentEvent({
+  const AgentEvent({
     required this.id,
     required this.type,
     required this.message,

--- a/packages/gen/examples/spacetraders/lib/model/agent_event.dart
+++ b/packages/gen/examples/spacetraders/lib/model/agent_event.dart
@@ -41,4 +41,18 @@ class AgentEvent {
       'createdAt': createdAt.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(id, type, message, data, createdAt);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AgentEvent &&
+        id == other.id &&
+        type == other.type &&
+        message == other.message &&
+        identical(data, other.data) &&
+        createdAt == other.createdAt;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/chart.dart
+++ b/packages/gen/examples/spacetraders/lib/model/chart.dart
@@ -33,4 +33,16 @@ class Chart {
       'submittedOn': submittedOn.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(waypointSymbol, submittedBy, submittedOn);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Chart &&
+        waypointSymbol == other.waypointSymbol &&
+        submittedBy == other.submittedBy &&
+        submittedOn == other.submittedOn;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/chart.dart
+++ b/packages/gen/examples/spacetraders/lib/model/chart.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class Chart {
-  Chart({
+  const Chart({
     required this.waypointSymbol,
     required this.submittedBy,
     required this.submittedOn,

--- a/packages/gen/examples/spacetraders/lib/model/chart_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/chart_transaction.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ChartTransaction {
-  ChartTransaction({
+  const ChartTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.totalPrice,

--- a/packages/gen/examples/spacetraders/lib/model/chart_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/chart_transaction.dart
@@ -37,4 +37,18 @@ class ChartTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(waypointSymbol, shipSymbol, totalPrice, timestamp);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ChartTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        totalPrice == other.totalPrice &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/construction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/construction.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/construction_material.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Construction {
-  Construction({
+  const Construction({
     required this.symbol,
     required this.isComplete,
     this.materials = const [],

--- a/packages/gen/examples/spacetraders/lib/model/construction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/construction.dart
@@ -40,4 +40,16 @@ class Construction {
       'isComplete': isComplete,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, materials, isComplete);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Construction &&
+        symbol == other.symbol &&
+        listsEqual(materials, other.materials) &&
+        isComplete == other.isComplete;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/construction_material.dart
+++ b/packages/gen/examples/spacetraders/lib/model/construction_material.dart
@@ -10,7 +10,7 @@ class ConstructionMaterial {
   factory ConstructionMaterial.fromJson(Map<String, dynamic> json) {
     return ConstructionMaterial(
       tradeSymbol: TradeSymbol.fromJson(json['tradeSymbol'] as String),
-      required: json['required'] as int,
+      required_: json['required'] as int,
       fulfilled: json['fulfilled'] as int,
     );
   }

--- a/packages/gen/examples/spacetraders/lib/model/construction_material.dart
+++ b/packages/gen/examples/spacetraders/lib/model/construction_material.dart
@@ -10,7 +10,7 @@ class ConstructionMaterial {
   factory ConstructionMaterial.fromJson(Map<String, dynamic> json) {
     return ConstructionMaterial(
       tradeSymbol: TradeSymbol.fromJson(json['tradeSymbol'] as String),
-      required_: json['required'] as int,
+      required: json['required'] as int,
       fulfilled: json['fulfilled'] as int,
     );
   }
@@ -31,8 +31,20 @@ class ConstructionMaterial {
   Map<String, dynamic> toJson() {
     return {
       'tradeSymbol': tradeSymbol.toJson(),
-      'required_': required_,
+      'required': required_,
       'fulfilled': fulfilled,
     };
+  }
+
+  @override
+  int get hashCode => Object.hash(tradeSymbol, required_, fulfilled);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ConstructionMaterial &&
+        tradeSymbol == other.tradeSymbol &&
+        required_ == other.required_ &&
+        fulfilled == other.fulfilled;
   }
 }

--- a/packages/gen/examples/spacetraders/lib/model/construction_material.dart
+++ b/packages/gen/examples/spacetraders/lib/model/construction_material.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class ConstructionMaterial {
-  ConstructionMaterial({
+  const ConstructionMaterial({
     required this.tradeSymbol,
     required this.required_,
     required this.fulfilled,

--- a/packages/gen/examples/spacetraders/lib/model/contract.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract.dart
@@ -56,4 +56,30 @@ class Contract {
       'deadlineToAccept': deadlineToAccept?.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    factionSymbol,
+    type,
+    terms,
+    accepted,
+    fulfilled,
+    expiration,
+    deadlineToAccept,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Contract &&
+        id == other.id &&
+        factionSymbol == other.factionSymbol &&
+        type == other.type &&
+        terms == other.terms &&
+        accepted == other.accepted &&
+        fulfilled == other.fulfilled &&
+        expiration == other.expiration &&
+        deadlineToAccept == other.deadlineToAccept;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/contract.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract_terms.dart';
 import 'package:spacetraders/model/contract_type.dart';
 
+@immutable
 class Contract {
-  Contract({
+  const Contract({
     required this.id,
     required this.factionSymbol,
     required this.type,

--- a/packages/gen/examples/spacetraders/lib/model/contract_deliver_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_deliver_good.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ContractDeliverGood {
-  ContractDeliverGood({
+  const ContractDeliverGood({
     required this.tradeSymbol,
     required this.destinationSymbol,
     required this.unitsRequired,

--- a/packages/gen/examples/spacetraders/lib/model/contract_deliver_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_deliver_good.dart
@@ -37,4 +37,22 @@ class ContractDeliverGood {
       'unitsFulfilled': unitsFulfilled,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    tradeSymbol,
+    destinationSymbol,
+    unitsRequired,
+    unitsFulfilled,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ContractDeliverGood &&
+        tradeSymbol == other.tradeSymbol &&
+        destinationSymbol == other.destinationSymbol &&
+        unitsRequired == other.unitsRequired &&
+        unitsFulfilled == other.unitsFulfilled;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/contract_payment.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_payment.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ContractPayment {
-  ContractPayment({required this.onAccepted, required this.onFulfilled});
+  const ContractPayment({required this.onAccepted, required this.onFulfilled});
 
   factory ContractPayment.fromJson(Map<String, dynamic> json) {
     return ContractPayment(

--- a/packages/gen/examples/spacetraders/lib/model/contract_payment.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_payment.dart
@@ -23,4 +23,15 @@ class ContractPayment {
   Map<String, dynamic> toJson() {
     return {'onAccepted': onAccepted, 'onFulfilled': onFulfilled};
   }
+
+  @override
+  int get hashCode => Object.hash(onAccepted, onFulfilled);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ContractPayment &&
+        onAccepted == other.onAccepted &&
+        onFulfilled == other.onFulfilled;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/contract_terms.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_terms.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract_deliver_good.dart';
 import 'package:spacetraders/model/contract_payment.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ContractTerms {
-  ContractTerms({
+  const ContractTerms({
     required this.deadline,
     required this.payment,
     this.deliver = const [],

--- a/packages/gen/examples/spacetraders/lib/model/contract_terms.dart
+++ b/packages/gen/examples/spacetraders/lib/model/contract_terms.dart
@@ -43,4 +43,16 @@ class ContractTerms {
       'deliver': deliver?.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(deadline, payment, deliver);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ContractTerms &&
+        deadline == other.deadline &&
+        payment == other.payment &&
+        listsEqual(deliver, other.deliver);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/cooldown.dart
+++ b/packages/gen/examples/spacetraders/lib/model/cooldown.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class Cooldown {
-  Cooldown({
+  const Cooldown({
     required this.shipSymbol,
     required this.totalSeconds,
     required this.remainingSeconds,

--- a/packages/gen/examples/spacetraders/lib/model/cooldown.dart
+++ b/packages/gen/examples/spacetraders/lib/model/cooldown.dart
@@ -37,4 +37,18 @@ class Cooldown {
       'expiration': expiration?.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(shipSymbol, totalSeconds, remainingSeconds, expiration);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Cooldown &&
+        shipSymbol == other.shipSymbol &&
+        totalSeconds == other.totalSeconds &&
+        remainingSeconds == other.remainingSeconds &&
+        expiration == other.expiration;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_chart201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_chart201_response.dart
@@ -25,4 +25,13 @@ class CreateChart201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateChart201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_chart201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_chart201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/create_chart201_response_data.dart';
 
+@immutable
 class CreateChart201Response {
-  CreateChart201Response({required this.data});
+  const CreateChart201Response({required this.data});
 
   factory CreateChart201Response.fromJson(Map<String, dynamic> json) {
     return CreateChart201Response(

--- a/packages/gen/examples/spacetraders/lib/model/create_chart201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_chart201_response_data.dart
@@ -1,10 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/chart.dart';
 import 'package:spacetraders/model/chart_transaction.dart';
 import 'package:spacetraders/model/waypoint.dart';
 
+@immutable
 class CreateChart201ResponseData {
-  CreateChart201ResponseData({
+  const CreateChart201ResponseData({
     required this.chart,
     required this.waypoint,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/create_chart201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_chart201_response_data.dart
@@ -44,4 +44,17 @@ class CreateChart201ResponseData {
       'agent': agent.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(chart, waypoint, transaction, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateChart201ResponseData &&
+        chart == other.chart &&
+        waypoint == other.waypoint &&
+        transaction == other.transaction &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response.dart
@@ -27,4 +27,13 @@ class CreateShipShipScan201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipShipScan201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/create_ship_ship_scan201_response_data.dart';
 
+@immutable
 class CreateShipShipScan201Response {
-  CreateShipShipScan201Response({required this.data});
+  const CreateShipShipScan201Response({required this.data});
 
   factory CreateShipShipScan201Response.fromJson(Map<String, dynamic> json) {
     return CreateShipShipScan201Response(

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response_data.dart
@@ -41,4 +41,15 @@ class CreateShipShipScan201ResponseData {
       'ships': ships.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cooldown, ships);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipShipScan201ResponseData &&
+        cooldown == other.cooldown &&
+        listsEqual(ships, other.ships);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_ship_scan201_response_data.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/scanned_ship.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class CreateShipShipScan201ResponseData {
-  CreateShipShipScan201ResponseData({
+  const CreateShipShipScan201ResponseData({
     required this.cooldown,
     this.ships = const [],
   });

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response.dart
@@ -27,4 +27,13 @@ class CreateShipSystemScan201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipSystemScan201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/create_ship_system_scan201_response_data.dart';
 
+@immutable
 class CreateShipSystemScan201Response {
-  CreateShipSystemScan201Response({required this.data});
+  const CreateShipSystemScan201Response({required this.data});
 
   factory CreateShipSystemScan201Response.fromJson(Map<String, dynamic> json) {
     return CreateShipSystemScan201Response(

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response_data.dart
@@ -41,4 +41,15 @@ class CreateShipSystemScan201ResponseData {
       'systems': systems.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cooldown, systems);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipSystemScan201ResponseData &&
+        cooldown == other.cooldown &&
+        listsEqual(systems, other.systems);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_system_scan201_response_data.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/scanned_system.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class CreateShipSystemScan201ResponseData {
-  CreateShipSystemScan201ResponseData({
+  const CreateShipSystemScan201ResponseData({
     required this.cooldown,
     this.systems = const [],
   });

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response.dart
@@ -29,4 +29,13 @@ class CreateShipWaypointScan201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipWaypointScan201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/create_ship_waypoint_scan201_response_data.dart';
 
+@immutable
 class CreateShipWaypointScan201Response {
-  CreateShipWaypointScan201Response({required this.data});
+  const CreateShipWaypointScan201Response({required this.data});
 
   factory CreateShipWaypointScan201Response.fromJson(
     Map<String, dynamic> json,

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response_data.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/scanned_waypoint.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class CreateShipWaypointScan201ResponseData {
-  CreateShipWaypointScan201ResponseData({
+  const CreateShipWaypointScan201ResponseData({
     required this.cooldown,
     this.waypoints = const [],
   });

--- a/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_ship_waypoint_scan201_response_data.dart
@@ -41,4 +41,15 @@ class CreateShipWaypointScan201ResponseData {
       'waypoints': waypoints.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cooldown, waypoints);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateShipWaypointScan201ResponseData &&
+        cooldown == other.cooldown &&
+        listsEqual(waypoints, other.waypoints);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_survey201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_survey201_response.dart
@@ -25,4 +25,13 @@ class CreateSurvey201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateSurvey201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_survey201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_survey201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/create_survey201_response_data.dart';
 
+@immutable
 class CreateSurvey201Response {
-  CreateSurvey201Response({required this.data});
+  const CreateSurvey201Response({required this.data});
 
   factory CreateSurvey201Response.fromJson(Map<String, dynamic> json) {
     return CreateSurvey201Response(

--- a/packages/gen/examples/spacetraders/lib/model/create_survey201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_survey201_response_data.dart
@@ -37,4 +37,15 @@ class CreateSurvey201ResponseData {
       'surveys': surveys.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cooldown, surveys);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CreateSurvey201ResponseData &&
+        cooldown == other.cooldown &&
+        listsEqual(surveys, other.surveys);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/create_survey201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/create_survey201_response_data.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/survey.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class CreateSurvey201ResponseData {
-  CreateSurvey201ResponseData({
+  const CreateSurvey201ResponseData({
     required this.cooldown,
     this.surveys = const [],
   });

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response.dart
@@ -25,4 +25,13 @@ class DeliverContract200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DeliverContract200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/deliver_contract200_response_data.dart';
 
+@immutable
 class DeliverContract200Response {
-  DeliverContract200Response({required this.data});
+  const DeliverContract200Response({required this.data});
 
   factory DeliverContract200Response.fromJson(Map<String, dynamic> json) {
     return DeliverContract200Response(

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response_data.dart
@@ -1,8 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class DeliverContract200ResponseData {
-  DeliverContract200ResponseData({required this.contract, required this.cargo});
+  const DeliverContract200ResponseData({
+    required this.contract,
+    required this.cargo,
+  });
 
   factory DeliverContract200ResponseData.fromJson(Map<String, dynamic> json) {
     return DeliverContract200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract200_response_data.dart
@@ -28,4 +28,15 @@ class DeliverContract200ResponseData {
   Map<String, dynamic> toJson() {
     return {'contract': contract.toJson(), 'cargo': cargo.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(contract, cargo);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DeliverContract200ResponseData &&
+        contract == other.contract &&
+        cargo == other.cargo;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract_request.dart
@@ -33,4 +33,16 @@ class DeliverContractRequest {
       'units': units,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(shipSymbol, tradeSymbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DeliverContractRequest &&
+        shipSymbol == other.shipSymbol &&
+        tradeSymbol == other.tradeSymbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/deliver_contract_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/deliver_contract_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class DeliverContractRequest {
-  DeliverContractRequest({
+  const DeliverContractRequest({
     required this.shipSymbol,
     required this.tradeSymbol,
     required this.units,

--- a/packages/gen/examples/spacetraders/lib/model/dock_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/dock_ship200_response.dart
@@ -25,4 +25,13 @@ class DockShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DockShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/dock_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/dock_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/dock_ship200_response_data.dart';
 
+@immutable
 class DockShip200Response {
-  DockShip200Response({required this.data});
+  const DockShip200Response({required this.data});
 
   factory DockShip200Response.fromJson(Map<String, dynamic> json) {
     return DockShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/dock_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/dock_ship200_response_data.dart
@@ -23,4 +23,13 @@ class DockShip200ResponseData {
   Map<String, dynamic> toJson() {
     return {'nav': nav.toJson()};
   }
+
+  @override
+  int get hashCode => nav.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DockShip200ResponseData && nav == other.nav;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/dock_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/dock_ship200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 
+@immutable
 class DockShip200ResponseData {
-  DockShip200ResponseData({required this.nav});
+  const DockShip200ResponseData({required this.nav});
 
   factory DockShip200ResponseData.fromJson(Map<String, dynamic> json) {
     return DockShip200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources201_response.dart
@@ -27,4 +27,13 @@ class ExtractResources201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExtractResources201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/extract_resources201_response_data.dart';
 
+@immutable
 class ExtractResources201Response {
-  ExtractResources201Response({required this.data});
+  const ExtractResources201Response({required this.data});
 
   factory ExtractResources201Response.fromJson(Map<String, dynamic> json) {
     return ExtractResources201Response(

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources201_response_data.dart
@@ -61,4 +61,19 @@ class ExtractResources201ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(extraction, cooldown, cargo, modifiers, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExtractResources201ResponseData &&
+        extraction == other.extraction &&
+        cooldown == other.cooldown &&
+        cargo == other.cargo &&
+        listsEqual(modifiers, other.modifiers) &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources201_response_data.dart
@@ -1,11 +1,14 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/extraction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/waypoint_modifier.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ExtractResources201ResponseData {
-  ExtractResources201ResponseData({
+  const ExtractResources201ResponseData({
     required this.extraction,
     required this.cooldown,
     required this.cargo,

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/extract_resources_with_survey201_response_data.dart';
 
+@immutable
 class ExtractResourcesWithSurvey201Response {
-  ExtractResourcesWithSurvey201Response({required this.data});
+  const ExtractResourcesWithSurvey201Response({required this.data});
 
   factory ExtractResourcesWithSurvey201Response.fromJson(
     Map<String, dynamic> json,

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response.dart
@@ -29,4 +29,13 @@ class ExtractResourcesWithSurvey201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExtractResourcesWithSurvey201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response_data.dart
@@ -1,11 +1,14 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/extraction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/waypoint_modifier.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ExtractResourcesWithSurvey201ResponseData {
-  ExtractResourcesWithSurvey201ResponseData({
+  const ExtractResourcesWithSurvey201ResponseData({
     required this.extraction,
     required this.cooldown,
     required this.cargo,

--- a/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extract_resources_with_survey201_response_data.dart
@@ -63,4 +63,19 @@ class ExtractResourcesWithSurvey201ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(extraction, cooldown, cargo, modifiers, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExtractResourcesWithSurvey201ResponseData &&
+        extraction == other.extraction &&
+        cooldown == other.cooldown &&
+        cargo == other.cargo &&
+        listsEqual(modifiers, other.modifiers) &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extraction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extraction.dart
@@ -6,7 +6,7 @@ class Extraction {
   factory Extraction.fromJson(Map<String, dynamic> json) {
     return Extraction(
       shipSymbol: json['shipSymbol'] as String,
-      yield: ExtractionYield.fromJson(json['yield'] as Map<String, dynamic>),
+      yield_: ExtractionYield.fromJson(json['yield'] as Map<String, dynamic>),
     );
   }
 

--- a/packages/gen/examples/spacetraders/lib/model/extraction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extraction.dart
@@ -6,7 +6,7 @@ class Extraction {
   factory Extraction.fromJson(Map<String, dynamic> json) {
     return Extraction(
       shipSymbol: json['shipSymbol'] as String,
-      yield_: ExtractionYield.fromJson(json['yield'] as Map<String, dynamic>),
+      yield: ExtractionYield.fromJson(json['yield'] as Map<String, dynamic>),
     );
   }
 
@@ -23,6 +23,17 @@ class Extraction {
   final ExtractionYield yield_;
 
   Map<String, dynamic> toJson() {
-    return {'shipSymbol': shipSymbol, 'yield_': yield_.toJson()};
+    return {'shipSymbol': shipSymbol, 'yield': yield_.toJson()};
+  }
+
+  @override
+  int get hashCode => Object.hash(shipSymbol, yield_);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Extraction &&
+        shipSymbol == other.shipSymbol &&
+        yield_ == other.yield_;
   }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extraction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extraction.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/extraction_yield.dart';
 
+@immutable
 class Extraction {
-  Extraction({required this.shipSymbol, required this.yield_});
+  const Extraction({required this.shipSymbol, required this.yield_});
 
   factory Extraction.fromJson(Map<String, dynamic> json) {
     return Extraction(

--- a/packages/gen/examples/spacetraders/lib/model/extraction_yield.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extraction_yield.dart
@@ -25,4 +25,15 @@ class ExtractionYield {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExtractionYield &&
+        symbol == other.symbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/extraction_yield.dart
+++ b/packages/gen/examples/spacetraders/lib/model/extraction_yield.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class ExtractionYield {
-  ExtractionYield({required this.symbol, required this.units});
+  const ExtractionYield({required this.symbol, required this.units});
 
   factory ExtractionYield.fromJson(Map<String, dynamic> json) {
     return ExtractionYield(

--- a/packages/gen/examples/spacetraders/lib/model/faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/faction.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction_symbol.dart';
 import 'package:spacetraders/model/faction_trait.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Faction {
-  Faction({
+  const Faction({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/faction.dart
@@ -53,4 +53,26 @@ class Faction {
       'isRecruiting': isRecruiting,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    name,
+    description,
+    headquarters,
+    traits,
+    isRecruiting,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Faction &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description &&
+        headquarters == other.headquarters &&
+        listsEqual(traits, other.traits) &&
+        isRecruiting == other.isRecruiting;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/faction_trait.dart
+++ b/packages/gen/examples/spacetraders/lib/model/faction_trait.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction_trait_symbol.dart';
 
+@immutable
 class FactionTrait {
-  FactionTrait({
+  const FactionTrait({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/faction_trait.dart
+++ b/packages/gen/examples/spacetraders/lib/model/faction_trait.dart
@@ -35,4 +35,16 @@ class FactionTrait {
       'description': description,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, name, description);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FactionTrait &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/fulfill_contract200_response_data.dart';
 
+@immutable
 class FulfillContract200Response {
-  FulfillContract200Response({required this.data});
+  const FulfillContract200Response({required this.data});
 
   factory FulfillContract200Response.fromJson(Map<String, dynamic> json) {
     return FulfillContract200Response(

--- a/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response.dart
@@ -25,4 +25,13 @@ class FulfillContract200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FulfillContract200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response_data.dart
@@ -28,4 +28,15 @@ class FulfillContract200ResponseData {
   Map<String, dynamic> toJson() {
     return {'contract': contract.toJson(), 'agent': agent.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(contract, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FulfillContract200ResponseData &&
+        contract == other.contract &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/fulfill_contract200_response_data.dart
@@ -1,8 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/contract.dart';
 
+@immutable
 class FulfillContract200ResponseData {
-  FulfillContract200ResponseData({required this.contract, required this.agent});
+  const FulfillContract200ResponseData({
+    required this.contract,
+    required this.agent,
+  });
 
   factory FulfillContract200ResponseData.fromJson(Map<String, dynamic> json) {
     return FulfillContract200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/get_agent200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_agent200_response.dart
@@ -23,4 +23,13 @@ class GetAgent200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetAgent200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_agent200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_agent200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/public_agent.dart';
 
+@immutable
 class GetAgent200Response {
-  GetAgent200Response({required this.data});
+  const GetAgent200Response({required this.data});
 
   factory GetAgent200Response.fromJson(Map<String, dynamic> json) {
     return GetAgent200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_agents200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_agents200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/meta.dart';
 import 'package:spacetraders/model/public_agent.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetAgents200Response {
-  GetAgents200Response({required this.meta, this.data = const []});
+  const GetAgents200Response({required this.meta, this.data = const []});
 
   factory GetAgents200Response.fromJson(Map<String, dynamic> json) {
     return GetAgents200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_agents200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_agents200_response.dart
@@ -34,4 +34,15 @@ class GetAgents200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetAgents200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_construction200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_construction200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/construction.dart';
 
+@immutable
 class GetConstruction200Response {
-  GetConstruction200Response({required this.data});
+  const GetConstruction200Response({required this.data});
 
   factory GetConstruction200Response.fromJson(Map<String, dynamic> json) {
     return GetConstruction200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_construction200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_construction200_response.dart
@@ -23,4 +23,13 @@ class GetConstruction200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetConstruction200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_contract200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract.dart';
 
+@immutable
 class GetContract200Response {
-  GetContract200Response({required this.data});
+  const GetContract200Response({required this.data});
 
   factory GetContract200Response.fromJson(Map<String, dynamic> json) {
     return GetContract200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_contract200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_contract200_response.dart
@@ -23,4 +23,13 @@ class GetContract200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetContract200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_contracts200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_contracts200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract.dart';
 import 'package:spacetraders/model/meta.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetContracts200Response {
-  GetContracts200Response({required this.meta, this.data = const []});
+  const GetContracts200Response({required this.meta, this.data = const []});
 
   factory GetContracts200Response.fromJson(Map<String, dynamic> json) {
     return GetContracts200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_contracts200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_contracts200_response.dart
@@ -34,4 +34,15 @@ class GetContracts200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetContracts200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_error_codes200_response_error_codes_inner.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetErrorCodes200Response {
-  GetErrorCodes200Response({this.errorCodes = const []});
+  const GetErrorCodes200Response({this.errorCodes = const []});
 
   factory GetErrorCodes200Response.fromJson(Map<String, dynamic> json) {
     return GetErrorCodes200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response.dart
@@ -30,4 +30,14 @@ class GetErrorCodes200Response {
   Map<String, dynamic> toJson() {
     return {'errorCodes': errorCodes.map((e) => e.toJson()).toList()};
   }
+
+  @override
+  int get hashCode => errorCodes.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetErrorCodes200Response &&
+        listsEqual(errorCodes, other.errorCodes);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response_error_codes_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response_error_codes_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetErrorCodes200ResponseErrorCodesInner {
-  GetErrorCodes200ResponseErrorCodesInner({
+  const GetErrorCodes200ResponseErrorCodesInner({
     required this.code,
     required this.name,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response_error_codes_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_error_codes200_response_error_codes_inner.dart
@@ -30,4 +30,15 @@ class GetErrorCodes200ResponseErrorCodesInner {
   Map<String, dynamic> toJson() {
     return {'code': code, 'name': name};
   }
+
+  @override
+  int get hashCode => Object.hash(code, name);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetErrorCodes200ResponseErrorCodesInner &&
+        code == other.code &&
+        name == other.name;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_faction200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_faction200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction.dart';
 
+@immutable
 class GetFaction200Response {
-  GetFaction200Response({required this.data});
+  const GetFaction200Response({required this.data});
 
   factory GetFaction200Response.fromJson(Map<String, dynamic> json) {
     return GetFaction200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_faction200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_faction200_response.dart
@@ -23,4 +23,13 @@ class GetFaction200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetFaction200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_factions200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_factions200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction.dart';
 import 'package:spacetraders/model/meta.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetFactions200Response {
-  GetFactions200Response({required this.meta, this.data = const []});
+  const GetFactions200Response({required this.meta, this.data = const []});
 
   factory GetFactions200Response.fromJson(Map<String, dynamic> json) {
     return GetFactions200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_factions200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_factions200_response.dart
@@ -32,4 +32,15 @@ class GetFactions200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetFactions200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_jump_gate200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_jump_gate200_response.dart
@@ -23,4 +23,13 @@ class GetJumpGate200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetJumpGate200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_jump_gate200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_jump_gate200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/jump_gate.dart';
 
+@immutable
 class GetJumpGate200Response {
-  GetJumpGate200Response({required this.data});
+  const GetJumpGate200Response({required this.data});
 
   factory GetJumpGate200Response.fromJson(Map<String, dynamic> json) {
     return GetJumpGate200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_market200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_market200_response.dart
@@ -23,4 +23,13 @@ class GetMarket200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMarket200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_market200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_market200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/market.dart';
 
+@immutable
 class GetMarket200Response {
-  GetMarket200Response({required this.data});
+  const GetMarket200Response({required this.data});
 
   factory GetMarket200Response.fromJson(Map<String, dynamic> json) {
     return GetMarket200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_mounts200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_mounts200_response.dart
@@ -28,4 +28,13 @@ class GetMounts200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.map((e) => e.toJson()).toList()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMounts200Response && listsEqual(data, other.data);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_mounts200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_mounts200_response.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_mount.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetMounts200Response {
-  GetMounts200Response({this.data = const []});
+  const GetMounts200Response({this.data = const []});
 
   factory GetMounts200Response.fromJson(Map<String, dynamic> json) {
     return GetMounts200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response.dart
@@ -25,4 +25,13 @@ class GetMyAccount200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyAccount200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_my_account200_response_data.dart';
 
+@immutable
 class GetMyAccount200Response {
-  GetMyAccount200Response({required this.data});
+  const GetMyAccount200Response({required this.data});
 
   factory GetMyAccount200Response.fromJson(Map<String, dynamic> json) {
     return GetMyAccount200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data.dart
@@ -27,4 +27,13 @@ class GetMyAccount200ResponseData {
   Map<String, dynamic> toJson() {
     return {'account': account.toJson()};
   }
+
+  @override
+  int get hashCode => account.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyAccount200ResponseData && account == other.account;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_my_account200_response_data_account.dart';
 
+@immutable
 class GetMyAccount200ResponseData {
-  GetMyAccount200ResponseData({required this.account});
+  const GetMyAccount200ResponseData({required this.account});
 
   factory GetMyAccount200ResponseData.fromJson(Map<String, dynamic> json) {
     return GetMyAccount200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data_account.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data_account.dart
@@ -41,4 +41,17 @@ class GetMyAccount200ResponseDataAccount {
       'createdAt': createdAt.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(id, email, token, createdAt);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyAccount200ResponseDataAccount &&
+        id == other.id &&
+        email == other.email &&
+        token == other.token &&
+        createdAt == other.createdAt;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data_account.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_account200_response_data_account.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetMyAccount200ResponseDataAccount {
-  GetMyAccount200ResponseDataAccount({
+  const GetMyAccount200ResponseDataAccount({
     required this.id,
     required this.email,
     required this.createdAt,

--- a/packages/gen/examples/spacetraders/lib/model/get_my_agent200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_agent200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 
+@immutable
 class GetMyAgent200Response {
-  GetMyAgent200Response({required this.data});
+  const GetMyAgent200Response({required this.data});
 
   factory GetMyAgent200Response.fromJson(Map<String, dynamic> json) {
     return GetMyAgent200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_agent200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_agent200_response.dart
@@ -23,4 +23,13 @@ class GetMyAgent200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyAgent200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_agent_events200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_agent_events200_response.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent_event.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetMyAgentEvents200Response {
-  GetMyAgentEvents200Response({this.data = const []});
+  const GetMyAgentEvents200Response({this.data = const []});
 
   factory GetMyAgentEvents200Response.fromJson(Map<String, dynamic> json) {
     return GetMyAgentEvents200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_agent_events200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_agent_events200_response.dart
@@ -30,4 +30,13 @@ class GetMyAgentEvents200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.map((e) => e.toJson()).toList()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyAgentEvents200Response && listsEqual(data, other.data);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_my_factions200_response_data_inner.dart';
 import 'package:spacetraders/model/meta.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetMyFactions200Response {
-  GetMyFactions200Response({required this.meta, this.data = const []});
+  const GetMyFactions200Response({required this.meta, this.data = const []});
 
   factory GetMyFactions200Response.fromJson(Map<String, dynamic> json) {
     return GetMyFactions200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response.dart
@@ -36,4 +36,15 @@ class GetMyFactions200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyFactions200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response_data_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response_data_inner.dart
@@ -30,4 +30,15 @@ class GetMyFactions200ResponseDataInner {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol, 'reputation': reputation};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, reputation);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyFactions200ResponseDataInner &&
+        symbol == other.symbol &&
+        reputation == other.reputation;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response_data_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_factions200_response_data_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetMyFactions200ResponseDataInner {
-  GetMyFactions200ResponseDataInner({
+  const GetMyFactions200ResponseDataInner({
     required this.symbol,
     required this.reputation,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ship200_response.dart
@@ -23,4 +23,13 @@ class GetMyShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship.dart';
 
+@immutable
 class GetMyShip200Response {
-  GetMyShip200Response({required this.data});
+  const GetMyShip200Response({required this.data});
 
   factory GetMyShip200Response.fromJson(Map<String, dynamic> json) {
     return GetMyShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ship_cargo200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ship_cargo200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class GetMyShipCargo200Response {
-  GetMyShipCargo200Response({required this.data});
+  const GetMyShipCargo200Response({required this.data});
 
   factory GetMyShipCargo200Response.fromJson(Map<String, dynamic> json) {
     return GetMyShipCargo200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ship_cargo200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ship_cargo200_response.dart
@@ -23,4 +23,13 @@ class GetMyShipCargo200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyShipCargo200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ships200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ships200_response.dart
@@ -32,4 +32,15 @@ class GetMyShips200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetMyShips200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_my_ships200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_my_ships200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/meta.dart';
 import 'package:spacetraders/model/ship.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetMyShips200Response {
-  GetMyShips200Response({required this.meta, this.data = const []});
+  const GetMyShips200Response({required this.meta, this.data = const []});
 
   factory GetMyShips200Response.fromJson(Map<String, dynamic> json) {
     return GetMyShips200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response.dart
@@ -25,4 +25,13 @@ class GetRepairShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetRepairShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_repair_ship200_response_data.dart';
 
+@immutable
 class GetRepairShip200Response {
-  GetRepairShip200Response({required this.data});
+  const GetRepairShip200Response({required this.data});
 
   factory GetRepairShip200Response.fromJson(Map<String, dynamic> json) {
     return GetRepairShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response_data.dart
@@ -27,4 +27,14 @@ class GetRepairShip200ResponseData {
   Map<String, dynamic> toJson() {
     return {'transaction': transaction.toJson()};
   }
+
+  @override
+  int get hashCode => transaction.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetRepairShip200ResponseData &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_repair_ship200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/repair_transaction.dart';
 
+@immutable
 class GetRepairShip200ResponseData {
-  GetRepairShip200ResponseData({required this.transaction});
+  const GetRepairShip200ResponseData({required this.transaction});
 
   factory GetRepairShip200ResponseData.fromJson(Map<String, dynamic> json) {
     return GetRepairShip200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_scrap_ship200_response_data.dart';
 
+@immutable
 class GetScrapShip200Response {
-  GetScrapShip200Response({required this.data});
+  const GetScrapShip200Response({required this.data});
 
   factory GetScrapShip200Response.fromJson(Map<String, dynamic> json) {
     return GetScrapShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response.dart
@@ -25,4 +25,13 @@ class GetScrapShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetScrapShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response_data.dart
@@ -27,4 +27,14 @@ class GetScrapShip200ResponseData {
   Map<String, dynamic> toJson() {
     return {'transaction': transaction.toJson()};
   }
+
+  @override
+  int get hashCode => transaction.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetScrapShip200ResponseData &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_scrap_ship200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/scrap_transaction.dart';
 
+@immutable
 class GetScrapShip200ResponseData {
-  GetScrapShip200ResponseData({required this.transaction});
+  const GetScrapShip200ResponseData({required this.transaction});
 
   factory GetScrapShip200ResponseData.fromJson(Map<String, dynamic> json) {
     return GetScrapShip200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_cooldown200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_cooldown200_response.dart
@@ -23,4 +23,13 @@ class GetShipCooldown200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetShipCooldown200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_cooldown200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_cooldown200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 
+@immutable
 class GetShipCooldown200Response {
-  GetShipCooldown200Response({required this.data});
+  const GetShipCooldown200Response({required this.data});
 
   factory GetShipCooldown200Response.fromJson(Map<String, dynamic> json) {
     return GetShipCooldown200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_modules200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_modules200_response.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_module.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetShipModules200Response {
-  GetShipModules200Response({this.data = const []});
+  const GetShipModules200Response({this.data = const []});
 
   factory GetShipModules200Response.fromJson(Map<String, dynamic> json) {
     return GetShipModules200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_modules200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_modules200_response.dart
@@ -28,4 +28,13 @@ class GetShipModules200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.map((e) => e.toJson()).toList()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetShipModules200Response && listsEqual(data, other.data);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_nav200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_nav200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 
+@immutable
 class GetShipNav200Response {
-  GetShipNav200Response({required this.data});
+  const GetShipNav200Response({required this.data});
 
   factory GetShipNav200Response.fromJson(Map<String, dynamic> json) {
     return GetShipNav200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_ship_nav200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_ship_nav200_response.dart
@@ -23,4 +23,13 @@ class GetShipNav200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetShipNav200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_shipyard200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_shipyard200_response.dart
@@ -23,4 +23,13 @@ class GetShipyard200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetShipyard200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_shipyard200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_shipyard200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/shipyard.dart';
 
+@immutable
 class GetShipyard200Response {
-  GetShipyard200Response({required this.data});
+  const GetShipyard200Response({required this.data});
 
   factory GetShipyard200Response.fromJson(Map<String, dynamic> json) {
     return GetShipyard200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response.dart
@@ -1,12 +1,15 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_status200_response_announcements_inner.dart';
 import 'package:spacetraders/model/get_status200_response_health.dart';
 import 'package:spacetraders/model/get_status200_response_leaderboards.dart';
 import 'package:spacetraders/model/get_status200_response_links_inner.dart';
 import 'package:spacetraders/model/get_status200_response_server_resets.dart';
 import 'package:spacetraders/model/get_status200_response_stats.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetStatus200Response {
-  GetStatus200Response({
+  const GetStatus200Response({
     required this.status,
     required this.version,
     required this.resetDate,

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response.dart
@@ -90,4 +90,34 @@ class GetStatus200Response {
       'links': links.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    status,
+    version,
+    resetDate,
+    description,
+    stats,
+    health,
+    leaderboards,
+    serverResets,
+    announcements,
+    links,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200Response &&
+        status == other.status &&
+        version == other.version &&
+        resetDate == other.resetDate &&
+        description == other.description &&
+        stats == other.stats &&
+        health == other.health &&
+        leaderboards == other.leaderboards &&
+        serverResets == other.serverResets &&
+        listsEqual(announcements, other.announcements) &&
+        listsEqual(links, other.links);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_announcements_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_announcements_inner.dart
@@ -30,4 +30,15 @@ class GetStatus200ResponseAnnouncementsInner {
   Map<String, dynamic> toJson() {
     return {'title': title, 'body': body};
   }
+
+  @override
+  int get hashCode => Object.hash(title, body);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseAnnouncementsInner &&
+        title == other.title &&
+        body == other.body;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_announcements_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_announcements_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseAnnouncementsInner {
-  GetStatus200ResponseAnnouncementsInner({
+  const GetStatus200ResponseAnnouncementsInner({
     required this.title,
     required this.body,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_health.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_health.dart
@@ -21,4 +21,14 @@ class GetStatus200ResponseHealth {
   Map<String, dynamic> toJson() {
     return {'lastMarketUpdate': lastMarketUpdate};
   }
+
+  @override
+  int get hashCode => lastMarketUpdate.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseHealth &&
+        lastMarketUpdate == other.lastMarketUpdate;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_health.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_health.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseHealth {
-  GetStatus200ResponseHealth({this.lastMarketUpdate});
+  const GetStatus200ResponseHealth({this.lastMarketUpdate});
 
   factory GetStatus200ResponseHealth.fromJson(Map<String, dynamic> json) {
     return GetStatus200ResponseHealth(

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_status200_response_leaderboards_most_credits_inner.dart';
 import 'package:spacetraders/model/get_status200_response_leaderboards_most_submitted_charts_inner.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetStatus200ResponseLeaderboards {
-  GetStatus200ResponseLeaderboards({
+  const GetStatus200ResponseLeaderboards({
     this.mostCredits = const [],
     this.mostSubmittedCharts = const [],
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards.dart
@@ -52,4 +52,15 @@ class GetStatus200ResponseLeaderboards {
           mostSubmittedCharts.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(mostCredits, mostSubmittedCharts);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseLeaderboards &&
+        listsEqual(mostCredits, other.mostCredits) &&
+        listsEqual(mostSubmittedCharts, other.mostSubmittedCharts);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_credits_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_credits_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseLeaderboardsMostCreditsInner {
-  GetStatus200ResponseLeaderboardsMostCreditsInner({
+  const GetStatus200ResponseLeaderboardsMostCreditsInner({
     required this.agentSymbol,
     required this.credits,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_credits_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_credits_inner.dart
@@ -30,4 +30,15 @@ class GetStatus200ResponseLeaderboardsMostCreditsInner {
   Map<String, dynamic> toJson() {
     return {'agentSymbol': agentSymbol, 'credits': credits};
   }
+
+  @override
+  int get hashCode => Object.hash(agentSymbol, credits);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseLeaderboardsMostCreditsInner &&
+        agentSymbol == other.agentSymbol &&
+        credits == other.credits;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_submitted_charts_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_submitted_charts_inner.dart
@@ -31,4 +31,15 @@ class GetStatus200ResponseLeaderboardsMostSubmittedChartsInner {
   Map<String, dynamic> toJson() {
     return {'agentSymbol': agentSymbol, 'chartCount': chartCount};
   }
+
+  @override
+  int get hashCode => Object.hash(agentSymbol, chartCount);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseLeaderboardsMostSubmittedChartsInner &&
+        agentSymbol == other.agentSymbol &&
+        chartCount == other.chartCount;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_submitted_charts_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_leaderboards_most_submitted_charts_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseLeaderboardsMostSubmittedChartsInner {
-  GetStatus200ResponseLeaderboardsMostSubmittedChartsInner({
+  const GetStatus200ResponseLeaderboardsMostSubmittedChartsInner({
     required this.agentSymbol,
     required this.chartCount,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_links_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_links_inner.dart
@@ -25,4 +25,15 @@ class GetStatus200ResponseLinksInner {
   Map<String, dynamic> toJson() {
     return {'name': name, 'url': url};
   }
+
+  @override
+  int get hashCode => Object.hash(name, url);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseLinksInner &&
+        name == other.name &&
+        url == other.url;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_links_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_links_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseLinksInner {
-  GetStatus200ResponseLinksInner({required this.name, required this.url});
+  const GetStatus200ResponseLinksInner({required this.name, required this.url});
 
   factory GetStatus200ResponseLinksInner.fromJson(Map<String, dynamic> json) {
     return GetStatus200ResponseLinksInner(

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_server_resets.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_server_resets.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseServerResets {
-  GetStatus200ResponseServerResets({
+  const GetStatus200ResponseServerResets({
     required this.next,
     required this.frequency,
   });

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_server_resets.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_server_resets.dart
@@ -28,4 +28,15 @@ class GetStatus200ResponseServerResets {
   Map<String, dynamic> toJson() {
     return {'next': next, 'frequency': frequency};
   }
+
+  @override
+  int get hashCode => Object.hash(next, frequency);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseServerResets &&
+        next == other.next &&
+        frequency == other.frequency;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_stats.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_stats.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class GetStatus200ResponseStats {
-  GetStatus200ResponseStats({
+  const GetStatus200ResponseStats({
     required this.agents,
     required this.ships,
     required this.systems,

--- a/packages/gen/examples/spacetraders/lib/model/get_status200_response_stats.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_status200_response_stats.dart
@@ -41,4 +41,18 @@ class GetStatus200ResponseStats {
       'waypoints': waypoints,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(accounts, agents, ships, systems, waypoints);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetStatus200ResponseStats &&
+        accounts == other.accounts &&
+        agents == other.agents &&
+        ships == other.ships &&
+        systems == other.systems &&
+        waypoints == other.waypoints;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_supply_chain200_response_data.dart';
 
+@immutable
 class GetSupplyChain200Response {
-  GetSupplyChain200Response({required this.data});
+  const GetSupplyChain200Response({required this.data});
 
   factory GetSupplyChain200Response.fromJson(Map<String, dynamic> json) {
     return GetSupplyChain200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response.dart
@@ -25,4 +25,13 @@ class GetSupplyChain200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSupplyChain200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data.dart
@@ -28,4 +28,14 @@ class GetSupplyChain200ResponseData {
   Map<String, dynamic> toJson() {
     return {'exportToImportMap': exportToImportMap.toJson()};
   }
+
+  @override
+  int get hashCode => exportToImportMap.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSupplyChain200ResponseData &&
+        exportToImportMap == other.exportToImportMap;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/get_supply_chain200_response_data_export_to_import_map.dart';
 
+@immutable
 class GetSupplyChain200ResponseData {
-  GetSupplyChain200ResponseData({required this.exportToImportMap});
+  const GetSupplyChain200ResponseData({required this.exportToImportMap});
 
   factory GetSupplyChain200ResponseData.fromJson(Map<String, dynamic> json) {
     return GetSupplyChain200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data_export_to_import_map.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data_export_to_import_map.dart
@@ -29,4 +29,14 @@ class GetSupplyChain200ResponseDataExportToImportMap {
   Map<String, dynamic> toJson() {
     return {...entries.map(MapEntry.new)};
   }
+
+  @override
+  int get hashCode => entries.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSupplyChain200ResponseDataExportToImportMap &&
+        mapsEqual(entries, other.entries);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data_export_to_import_map.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_supply_chain200_response_data_export_to_import_map.dart
@@ -1,5 +1,9 @@
+import 'package:meta/meta.dart';
+import 'package:spacetraders/model_helpers.dart';
+
+@immutable
 class GetSupplyChain200ResponseDataExportToImportMap {
-  GetSupplyChain200ResponseDataExportToImportMap({required this.entries});
+  const GetSupplyChain200ResponseDataExportToImportMap({required this.entries});
 
   factory GetSupplyChain200ResponseDataExportToImportMap.fromJson(
     Map<String, dynamic> json,

--- a/packages/gen/examples/spacetraders/lib/model/get_system200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_system200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/system.dart';
 
+@immutable
 class GetSystem200Response {
-  GetSystem200Response({required this.data});
+  const GetSystem200Response({required this.data});
 
   factory GetSystem200Response.fromJson(Map<String, dynamic> json) {
     return GetSystem200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_system200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_system200_response.dart
@@ -23,4 +23,13 @@ class GetSystem200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSystem200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_system_waypoints200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_system_waypoints200_response.dart
@@ -36,4 +36,15 @@ class GetSystemWaypoints200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSystemWaypoints200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_system_waypoints200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_system_waypoints200_response.dart
@@ -1,8 +1,14 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/meta.dart';
 import 'package:spacetraders/model/waypoint.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetSystemWaypoints200Response {
-  GetSystemWaypoints200Response({required this.meta, this.data = const []});
+  const GetSystemWaypoints200Response({
+    required this.meta,
+    this.data = const [],
+  });
 
   factory GetSystemWaypoints200Response.fromJson(Map<String, dynamic> json) {
     return GetSystemWaypoints200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_systems200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_systems200_response.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/meta.dart';
 import 'package:spacetraders/model/system.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class GetSystems200Response {
-  GetSystems200Response({required this.meta, this.data = const []});
+  const GetSystems200Response({required this.meta, this.data = const []});
 
   factory GetSystems200Response.fromJson(Map<String, dynamic> json) {
     return GetSystems200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_systems200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_systems200_response.dart
@@ -32,4 +32,15 @@ class GetSystems200Response {
       'meta': meta.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(data, meta);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetSystems200Response &&
+        listsEqual(data, other.data) &&
+        meta == other.meta;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/get_waypoint200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_waypoint200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/waypoint.dart';
 
+@immutable
 class GetWaypoint200Response {
-  GetWaypoint200Response({required this.data});
+  const GetWaypoint200Response({required this.data});
 
   factory GetWaypoint200Response.fromJson(Map<String, dynamic> json) {
     return GetWaypoint200Response(

--- a/packages/gen/examples/spacetraders/lib/model/get_waypoint200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/get_waypoint200_response.dart
@@ -23,4 +23,13 @@ class GetWaypoint200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GetWaypoint200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_mount201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount201_response.dart
@@ -25,4 +25,13 @@ class InstallMount201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallMount201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_mount201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/install_mount201_response_data.dart';
 
+@immutable
 class InstallMount201Response {
-  InstallMount201Response({required this.data});
+  const InstallMount201Response({required this.data});
 
   factory InstallMount201Response.fromJson(Map<String, dynamic> json) {
     return InstallMount201Response(

--- a/packages/gen/examples/spacetraders/lib/model/install_mount201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount201_response_data.dart
@@ -51,4 +51,17 @@ class InstallMount201ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, mounts, cargo, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallMount201ResponseData &&
+        agent == other.agent &&
+        listsEqual(mounts, other.mounts) &&
+        cargo == other.cargo &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_mount201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_modification_transaction.dart';
 import 'package:spacetraders/model/ship_mount.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class InstallMount201ResponseData {
-  InstallMount201ResponseData({
+  const InstallMount201ResponseData({
     required this.agent,
     required this.cargo,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/install_mount_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class InstallMountRequest {
-  InstallMountRequest({required this.symbol});
+  const InstallMountRequest({required this.symbol});
 
   factory InstallMountRequest.fromJson(Map<String, dynamic> json) {
     return InstallMountRequest(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/install_mount_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_mount_request.dart
@@ -19,4 +19,13 @@ class InstallMountRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallMountRequest && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response.dart
@@ -27,4 +27,13 @@ class InstallShipModule201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallShipModule201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/install_ship_module201_response_data.dart';
 
+@immutable
 class InstallShipModule201Response {
-  InstallShipModule201Response({required this.data});
+  const InstallShipModule201Response({required this.data});
 
   factory InstallShipModule201Response.fromJson(Map<String, dynamic> json) {
     return InstallShipModule201Response(

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response_data.dart
@@ -51,4 +51,17 @@ class InstallShipModule201ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, modules, cargo, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallShipModule201ResponseData &&
+        agent == other.agent &&
+        listsEqual(modules, other.modules) &&
+        cargo == other.cargo &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_modification_transaction.dart';
 import 'package:spacetraders/model/ship_module.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class InstallShipModule201ResponseData {
-  InstallShipModule201ResponseData({
+  const InstallShipModule201ResponseData({
     required this.agent,
     required this.cargo,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class InstallShipModuleRequest {
-  InstallShipModuleRequest({required this.symbol});
+  const InstallShipModuleRequest({required this.symbol});
 
   factory InstallShipModuleRequest.fromJson(Map<String, dynamic> json) {
     return InstallShipModuleRequest(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/install_ship_module_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/install_ship_module_request.dart
@@ -19,4 +19,13 @@ class InstallShipModuleRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InstallShipModuleRequest && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jettison200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/jettison200_response_data.dart';
 
+@immutable
 class Jettison200Response {
-  Jettison200Response({required this.data});
+  const Jettison200Response({required this.data});
 
   factory Jettison200Response.fromJson(Map<String, dynamic> json) {
     return Jettison200Response(

--- a/packages/gen/examples/spacetraders/lib/model/jettison200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison200_response.dart
@@ -25,4 +25,13 @@ class Jettison200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Jettison200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jettison200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class Jettison200ResponseData {
-  Jettison200ResponseData({required this.cargo});
+  const Jettison200ResponseData({required this.cargo});
 
   factory Jettison200ResponseData.fromJson(Map<String, dynamic> json) {
     return Jettison200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/jettison200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison200_response_data.dart
@@ -23,4 +23,13 @@ class Jettison200ResponseData {
   Map<String, dynamic> toJson() {
     return {'cargo': cargo.toJson()};
   }
+
+  @override
+  int get hashCode => cargo.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Jettison200ResponseData && cargo == other.cargo;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jettison_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison_request.dart
@@ -25,4 +25,15 @@ class JettisonRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is JettisonRequest &&
+        symbol == other.symbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jettison_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jettison_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class JettisonRequest {
-  JettisonRequest({required this.symbol, required this.units});
+  const JettisonRequest({required this.symbol, required this.units});
 
   factory JettisonRequest.fromJson(Map<String, dynamic> json) {
     return JettisonRequest(

--- a/packages/gen/examples/spacetraders/lib/model/jump_gate.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_gate.dart
@@ -23,4 +23,15 @@ class JumpGate {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol, 'connections': connections};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, connections);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is JumpGate &&
+        symbol == other.symbol &&
+        listsEqual(connections, other.connections);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jump_gate.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_gate.dart
@@ -1,5 +1,9 @@
+import 'package:meta/meta.dart';
+import 'package:spacetraders/model_helpers.dart';
+
+@immutable
 class JumpGate {
-  JumpGate({required this.symbol, this.connections = const []});
+  const JumpGate({required this.symbol, this.connections = const []});
 
   factory JumpGate.fromJson(Map<String, dynamic> json) {
     return JumpGate(

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/jump_ship200_response_data.dart';
 
+@immutable
 class JumpShip200Response {
-  JumpShip200Response({required this.data});
+  const JumpShip200Response({required this.data});
 
   factory JumpShip200Response.fromJson(Map<String, dynamic> json) {
     return JumpShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship200_response.dart
@@ -25,4 +25,13 @@ class JumpShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is JumpShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship200_response_data.dart
@@ -44,4 +44,17 @@ class JumpShip200ResponseData {
       'agent': agent.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(nav, cooldown, transaction, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is JumpShip200ResponseData &&
+        nav == other.nav &&
+        cooldown == other.cooldown &&
+        transaction == other.transaction &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship200_response_data.dart
@@ -1,10 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/market_transaction.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 
+@immutable
 class JumpShip200ResponseData {
-  JumpShip200ResponseData({
+  const JumpShip200ResponseData({
     required this.nav,
     required this.cooldown,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class JumpShipRequest {
-  JumpShipRequest({required this.waypointSymbol});
+  const JumpShipRequest({required this.waypointSymbol});
 
   factory JumpShipRequest.fromJson(Map<String, dynamic> json) {
     return JumpShipRequest(waypointSymbol: json['waypointSymbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/jump_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/jump_ship_request.dart
@@ -19,4 +19,13 @@ class JumpShipRequest {
   Map<String, dynamic> toJson() {
     return {'waypointSymbol': waypointSymbol};
   }
+
+  @override
+  int get hashCode => waypointSymbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is JumpShipRequest && waypointSymbol == other.waypointSymbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/market.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market.dart
@@ -74,4 +74,20 @@ class Market {
       'tradeGoods': tradeGoods?.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, exports, imports, exchange, transactions, tradeGoods);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Market &&
+        symbol == other.symbol &&
+        listsEqual(exports, other.exports) &&
+        listsEqual(imports, other.imports) &&
+        listsEqual(exchange, other.exchange) &&
+        listsEqual(transactions, other.transactions) &&
+        listsEqual(tradeGoods, other.tradeGoods);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/market.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/market_trade_good.dart';
 import 'package:spacetraders/model/market_transaction.dart';
 import 'package:spacetraders/model/trade_good.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Market {
-  Market({
+  const Market({
     required this.symbol,
     this.exports = const [],
     this.imports = const [],

--- a/packages/gen/examples/spacetraders/lib/model/market_trade_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market_trade_good.dart
@@ -1,10 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/activity_level.dart';
 import 'package:spacetraders/model/market_trade_good_type.dart';
 import 'package:spacetraders/model/supply_level.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class MarketTradeGood {
-  MarketTradeGood({
+  const MarketTradeGood({
     required this.symbol,
     required this.type,
     required this.tradeVolume,

--- a/packages/gen/examples/spacetraders/lib/model/market_trade_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market_trade_good.dart
@@ -54,4 +54,28 @@ class MarketTradeGood {
       'sellPrice': sellPrice,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    type,
+    tradeVolume,
+    supply,
+    activity,
+    purchasePrice,
+    sellPrice,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MarketTradeGood &&
+        symbol == other.symbol &&
+        type == other.type &&
+        tradeVolume == other.tradeVolume &&
+        supply == other.supply &&
+        activity == other.activity &&
+        purchasePrice == other.purchasePrice &&
+        sellPrice == other.sellPrice;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/market_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market_transaction.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/market_transaction_type.dart';
 
+@immutable
 class MarketTransaction {
-  MarketTransaction({
+  const MarketTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.tradeSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/market_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/market_transaction.dart
@@ -55,4 +55,30 @@ class MarketTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    waypointSymbol,
+    shipSymbol,
+    tradeSymbol,
+    type,
+    units,
+    pricePerUnit,
+    totalPrice,
+    timestamp,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MarketTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        tradeSymbol == other.tradeSymbol &&
+        type == other.type &&
+        units == other.units &&
+        pricePerUnit == other.pricePerUnit &&
+        totalPrice == other.totalPrice &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/meta.dart
+++ b/packages/gen/examples/spacetraders/lib/model/meta.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class Meta {
-  Meta({required this.total, this.page = 1, this.limit = 10});
+  const Meta({required this.total, this.page = 1, this.limit = 10});
 
   factory Meta.fromJson(Map<String, dynamic> json) {
     return Meta(

--- a/packages/gen/examples/spacetraders/lib/model/meta.dart
+++ b/packages/gen/examples/spacetraders/lib/model/meta.dart
@@ -25,4 +25,16 @@ class Meta {
   Map<String, dynamic> toJson() {
     return {'total': total, 'page': page, 'limit': limit};
   }
+
+  @override
+  int get hashCode => Object.hash(total, page, limit);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Meta &&
+        total == other.total &&
+        page == other.page &&
+        limit == other.limit;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response.dart
@@ -25,4 +25,13 @@ class NavigateShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NavigateShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/navigate_ship200_response_data.dart';
 
+@immutable
 class NavigateShip200Response {
-  NavigateShip200Response({required this.data});
+  const NavigateShip200Response({required this.data});
 
   factory NavigateShip200Response.fromJson(Map<String, dynamic> json) {
     return NavigateShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response_data.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/ship_fuel.dart';
 import 'package:spacetraders/model/ship_nav.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class NavigateShip200ResponseData {
-  NavigateShip200ResponseData({
+  const NavigateShip200ResponseData({
     required this.nav,
     required this.fuel,
     this.events = const [],

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship200_response_data.dart
@@ -44,4 +44,16 @@ class NavigateShip200ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(nav, fuel, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NavigateShip200ResponseData &&
+        nav == other.nav &&
+        fuel == other.fuel &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class NavigateShipRequest {
-  NavigateShipRequest({required this.waypointSymbol});
+  const NavigateShipRequest({required this.waypointSymbol});
 
   factory NavigateShipRequest.fromJson(Map<String, dynamic> json) {
     return NavigateShipRequest(

--- a/packages/gen/examples/spacetraders/lib/model/navigate_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/navigate_ship_request.dart
@@ -21,4 +21,14 @@ class NavigateShipRequest {
   Map<String, dynamic> toJson() {
     return {'waypointSymbol': waypointSymbol};
   }
+
+  @override
+  int get hashCode => waypointSymbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NavigateShipRequest &&
+        waypointSymbol == other.waypointSymbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/negotiate_contract201_response_data.dart';
 
+@immutable
 class NegotiateContract201Response {
-  NegotiateContract201Response({required this.data});
+  const NegotiateContract201Response({required this.data});
 
   factory NegotiateContract201Response.fromJson(Map<String, dynamic> json) {
     return NegotiateContract201Response(

--- a/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response.dart
@@ -27,4 +27,13 @@ class NegotiateContract201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NegotiateContract201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response_data.dart
@@ -25,4 +25,14 @@ class NegotiateContract201ResponseData {
   Map<String, dynamic> toJson() {
     return {'contract': contract.toJson()};
   }
+
+  @override
+  int get hashCode => contract.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NegotiateContract201ResponseData &&
+        contract == other.contract;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/negotiate_contract201_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/contract.dart';
 
+@immutable
 class NegotiateContract201ResponseData {
-  NegotiateContract201ResponseData({required this.contract});
+  const NegotiateContract201ResponseData({required this.contract});
 
   factory NegotiateContract201ResponseData.fromJson(Map<String, dynamic> json) {
     return NegotiateContract201ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response.dart
@@ -25,4 +25,13 @@ class OrbitShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is OrbitShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/orbit_ship200_response_data.dart';
 
+@immutable
 class OrbitShip200Response {
-  OrbitShip200Response({required this.data});
+  const OrbitShip200Response({required this.data});
 
   factory OrbitShip200Response.fromJson(Map<String, dynamic> json) {
     return OrbitShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 
+@immutable
 class OrbitShip200ResponseData {
-  OrbitShip200ResponseData({required this.nav});
+  const OrbitShip200ResponseData({required this.nav});
 
   factory OrbitShip200ResponseData.fromJson(Map<String, dynamic> json) {
     return OrbitShip200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/orbit_ship200_response_data.dart
@@ -23,4 +23,13 @@ class OrbitShip200ResponseData {
   Map<String, dynamic> toJson() {
     return {'nav': nav.toJson()};
   }
+
+  @override
+  int get hashCode => nav.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is OrbitShip200ResponseData && nav == other.nav;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/patch_ship_nav200_response_data.dart';
 
+@immutable
 class PatchShipNav200Response {
-  PatchShipNav200Response({required this.data});
+  const PatchShipNav200Response({required this.data});
 
   factory PatchShipNav200Response.fromJson(Map<String, dynamic> json) {
     return PatchShipNav200Response(

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response.dart
@@ -25,4 +25,13 @@ class PatchShipNav200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PatchShipNav200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response_data.dart
@@ -44,4 +44,16 @@ class PatchShipNav200ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(nav, fuel, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PatchShipNav200ResponseData &&
+        nav == other.nav &&
+        fuel == other.fuel &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav200_response_data.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/ship_fuel.dart';
 import 'package:spacetraders/model/ship_nav.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class PatchShipNav200ResponseData {
-  PatchShipNav200ResponseData({
+  const PatchShipNav200ResponseData({
     required this.nav,
     required this.fuel,
     this.events = const [],

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav_flight_mode.dart';
 
+@immutable
 class PatchShipNavRequest {
-  PatchShipNavRequest({this.flightMode = ShipNavFlightMode.CRUISE});
+  const PatchShipNavRequest({this.flightMode = ShipNavFlightMode.CRUISE});
 
   factory PatchShipNavRequest.fromJson(Map<String, dynamic> json) {
     return PatchShipNavRequest(

--- a/packages/gen/examples/spacetraders/lib/model/patch_ship_nav_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/patch_ship_nav_request.dart
@@ -23,4 +23,13 @@ class PatchShipNavRequest {
   Map<String, dynamic> toJson() {
     return {'flightMode': flightMode?.toJson()};
   }
+
+  @override
+  int get hashCode => flightMode.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PatchShipNavRequest && flightMode == other.flightMode;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/public_agent.dart
+++ b/packages/gen/examples/spacetraders/lib/model/public_agent.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class PublicAgent {
-  PublicAgent({
+  const PublicAgent({
     required this.symbol,
     required this.headquarters,
     required this.credits,

--- a/packages/gen/examples/spacetraders/lib/model/public_agent.dart
+++ b/packages/gen/examples/spacetraders/lib/model/public_agent.dart
@@ -41,4 +41,19 @@ class PublicAgent {
       'shipCount': shipCount,
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, headquarters, credits, startingFaction, shipCount);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PublicAgent &&
+        symbol == other.symbol &&
+        headquarters == other.headquarters &&
+        credits == other.credits &&
+        startingFaction == other.startingFaction &&
+        shipCount == other.shipCount;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response.dart
@@ -25,4 +25,13 @@ class PurchaseCargo201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseCargo201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/purchase_cargo201_response_data.dart';
 
+@immutable
 class PurchaseCargo201Response {
-  PurchaseCargo201Response({required this.data});
+  const PurchaseCargo201Response({required this.data});
 
   factory PurchaseCargo201Response.fromJson(Map<String, dynamic> json) {
     return PurchaseCargo201Response(

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response_data.dart
@@ -41,4 +41,16 @@ class PurchaseCargo201ResponseData {
       'agent': agent.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cargo, transaction, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseCargo201ResponseData &&
+        cargo == other.cargo &&
+        transaction == other.transaction &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo201_response_data.dart
@@ -1,9 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/market_transaction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class PurchaseCargo201ResponseData {
-  PurchaseCargo201ResponseData({
+  const PurchaseCargo201ResponseData({
     required this.cargo,
     required this.transaction,
     required this.agent,

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class PurchaseCargoRequest {
-  PurchaseCargoRequest({required this.symbol, required this.units});
+  const PurchaseCargoRequest({required this.symbol, required this.units});
 
   factory PurchaseCargoRequest.fromJson(Map<String, dynamic> json) {
     return PurchaseCargoRequest(

--- a/packages/gen/examples/spacetraders/lib/model/purchase_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_cargo_request.dart
@@ -25,4 +25,15 @@ class PurchaseCargoRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseCargoRequest &&
+        symbol == other.symbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response.dart
@@ -25,4 +25,13 @@ class PurchaseShip201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseShip201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/purchase_ship201_response_data.dart';
 
+@immutable
 class PurchaseShip201Response {
-  PurchaseShip201Response({required this.data});
+  const PurchaseShip201Response({required this.data});
 
   factory PurchaseShip201Response.fromJson(Map<String, dynamic> json) {
     return PurchaseShip201Response(

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response_data.dart
@@ -41,4 +41,16 @@ class PurchaseShip201ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(ship, agent, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseShip201ResponseData &&
+        ship == other.ship &&
+        agent == other.agent &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship201_response_data.dart
@@ -1,9 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/ship.dart';
 import 'package:spacetraders/model/shipyard_transaction.dart';
 
+@immutable
 class PurchaseShip201ResponseData {
-  PurchaseShip201ResponseData({
+  const PurchaseShip201ResponseData({
     required this.ship,
     required this.agent,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship_request.dart
@@ -25,4 +25,15 @@ class PurchaseShipRequest {
   Map<String, dynamic> toJson() {
     return {'shipType': shipType.toJson(), 'waypointSymbol': waypointSymbol};
   }
+
+  @override
+  int get hashCode => Object.hash(shipType, waypointSymbol);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PurchaseShipRequest &&
+        shipType == other.shipType &&
+        waypointSymbol == other.waypointSymbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/purchase_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/purchase_ship_request.dart
@@ -1,7 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_type.dart';
 
+@immutable
 class PurchaseShipRequest {
-  PurchaseShipRequest({required this.shipType, required this.waypointSymbol});
+  const PurchaseShipRequest({
+    required this.shipType,
+    required this.waypointSymbol,
+  });
 
   factory PurchaseShipRequest.fromJson(Map<String, dynamic> json) {
     return PurchaseShipRequest(

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response.dart
@@ -25,4 +25,13 @@ class RefuelShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RefuelShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/refuel_ship200_response_data.dart';
 
+@immutable
 class RefuelShip200Response {
-  RefuelShip200Response({required this.data});
+  const RefuelShip200Response({required this.data});
 
   factory RefuelShip200Response.fromJson(Map<String, dynamic> json) {
     return RefuelShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response_data.dart
@@ -44,4 +44,17 @@ class RefuelShip200ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, fuel, cargo, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RefuelShip200ResponseData &&
+        agent == other.agent &&
+        fuel == other.fuel &&
+        cargo == other.cargo &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship200_response_data.dart
@@ -1,10 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/market_transaction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_fuel.dart';
 
+@immutable
 class RefuelShip200ResponseData {
-  RefuelShip200ResponseData({
+  const RefuelShip200ResponseData({
     required this.agent,
     required this.fuel,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship_request.dart
@@ -23,4 +23,15 @@ class RefuelShipRequest {
   Map<String, dynamic> toJson() {
     return {'units': units, 'fromCargo': fromCargo};
   }
+
+  @override
+  int get hashCode => Object.hash(units, fromCargo);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RefuelShipRequest &&
+        units == other.units &&
+        identical(fromCargo, other.fromCargo);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/refuel_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/refuel_ship_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RefuelShipRequest {
-  RefuelShipRequest({this.units, this.fromCargo = false});
+  const RefuelShipRequest({this.units, this.fromCargo = false});
 
   factory RefuelShipRequest.fromJson(Map<String, dynamic> json) {
     return RefuelShipRequest(

--- a/packages/gen/examples/spacetraders/lib/model/register201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/register201_response_data.dart';
 
+@immutable
 class Register201Response {
-  Register201Response({required this.data});
+  const Register201Response({required this.data});
 
   factory Register201Response.fromJson(Map<String, dynamic> json) {
     return Register201Response(

--- a/packages/gen/examples/spacetraders/lib/model/register201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register201_response.dart
@@ -25,4 +25,13 @@ class Register201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Register201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/register201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/contract.dart';
 import 'package:spacetraders/model/faction.dart';
 import 'package:spacetraders/model/ship.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Register201ResponseData {
-  Register201ResponseData({
+  const Register201ResponseData({
     required this.token,
     required this.agent,
     required this.faction,

--- a/packages/gen/examples/spacetraders/lib/model/register201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register201_response_data.dart
@@ -49,4 +49,18 @@ class Register201ResponseData {
       'ships': ships.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(token, agent, faction, contract, ships);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Register201ResponseData &&
+        token == other.token &&
+        agent == other.agent &&
+        faction == other.faction &&
+        contract == other.contract &&
+        listsEqual(ships, other.ships);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/register_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction_symbol.dart';
 
+@immutable
 class RegisterRequest {
-  RegisterRequest({required this.symbol, required this.faction});
+  const RegisterRequest({required this.symbol, required this.faction});
 
   factory RegisterRequest.fromJson(Map<String, dynamic> json) {
     return RegisterRequest(

--- a/packages/gen/examples/spacetraders/lib/model/register_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/register_request.dart
@@ -25,4 +25,15 @@ class RegisterRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol, 'faction': faction.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, faction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RegisterRequest &&
+        symbol == other.symbol &&
+        faction == other.faction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/remove_mount201_response_data.dart';
 
+@immutable
 class RemoveMount201Response {
-  RemoveMount201Response({required this.data});
+  const RemoveMount201Response({required this.data});
 
   factory RemoveMount201Response.fromJson(Map<String, dynamic> json) {
     return RemoveMount201Response(

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount201_response.dart
@@ -25,4 +25,13 @@ class RemoveMount201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveMount201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount201_response_data.dart
@@ -49,4 +49,17 @@ class RemoveMount201ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, mounts, cargo, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveMount201ResponseData &&
+        agent == other.agent &&
+        listsEqual(mounts, other.mounts) &&
+        cargo == other.cargo &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_modification_transaction.dart';
 import 'package:spacetraders/model/ship_mount.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class RemoveMount201ResponseData {
-  RemoveMount201ResponseData({
+  const RemoveMount201ResponseData({
     required this.agent,
     required this.cargo,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount_request.dart
@@ -19,4 +19,13 @@ class RemoveMountRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveMountRequest && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_mount_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_mount_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RemoveMountRequest {
-  RemoveMountRequest({required this.symbol});
+  const RemoveMountRequest({required this.symbol});
 
   factory RemoveMountRequest.fromJson(Map<String, dynamic> json) {
     return RemoveMountRequest(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/remove_ship_module201_response_data.dart';
 
+@immutable
 class RemoveShipModule201Response {
-  RemoveShipModule201Response({required this.data});
+  const RemoveShipModule201Response({required this.data});
 
   factory RemoveShipModule201Response.fromJson(Map<String, dynamic> json) {
     return RemoveShipModule201Response(

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response.dart
@@ -27,4 +27,13 @@ class RemoveShipModule201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveShipModule201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response_data.dart
@@ -51,4 +51,17 @@ class RemoveShipModule201ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, modules, cargo, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveShipModule201ResponseData &&
+        agent == other.agent &&
+        listsEqual(modules, other.modules) &&
+        cargo == other.cargo &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_modification_transaction.dart';
 import 'package:spacetraders/model/ship_module.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class RemoveShipModule201ResponseData {
-  RemoveShipModule201ResponseData({
+  const RemoveShipModule201ResponseData({
     required this.agent,
     required this.cargo,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module_request.dart
@@ -19,4 +19,13 @@ class RemoveShipModuleRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RemoveShipModuleRequest && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/remove_ship_module_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/remove_ship_module_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RemoveShipModuleRequest {
-  RemoveShipModuleRequest({required this.symbol});
+  const RemoveShipModuleRequest({required this.symbol});
 
   factory RemoveShipModuleRequest.fromJson(Map<String, dynamic> json) {
     return RemoveShipModuleRequest(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/repair_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_ship200_response.dart
@@ -25,4 +25,13 @@ class RepairShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RepairShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/repair_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/repair_ship200_response_data.dart';
 
+@immutable
 class RepairShip200Response {
-  RepairShip200Response({required this.data});
+  const RepairShip200Response({required this.data});
 
   factory RepairShip200Response.fromJson(Map<String, dynamic> json) {
     return RepairShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/repair_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_ship200_response_data.dart
@@ -1,9 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/repair_transaction.dart';
 import 'package:spacetraders/model/ship.dart';
 
+@immutable
 class RepairShip200ResponseData {
-  RepairShip200ResponseData({
+  const RepairShip200ResponseData({
     required this.agent,
     required this.ship,
     required this.transaction,

--- a/packages/gen/examples/spacetraders/lib/model/repair_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_ship200_response_data.dart
@@ -39,4 +39,16 @@ class RepairShip200ResponseData {
       'transaction': transaction.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(agent, ship, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RepairShip200ResponseData &&
+        agent == other.agent &&
+        ship == other.ship &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/repair_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_transaction.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RepairTransaction {
-  RepairTransaction({
+  const RepairTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.totalPrice,

--- a/packages/gen/examples/spacetraders/lib/model/repair_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/repair_transaction.dart
@@ -37,4 +37,18 @@ class RepairTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(waypointSymbol, shipSymbol, totalPrice, timestamp);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RepairTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        totalPrice == other.totalPrice &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship.dart
@@ -68,4 +68,21 @@ class ScannedShip {
       'mounts': mounts?.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, registration, nav, frame, reactor, engine, mounts);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedShip &&
+        symbol == other.symbol &&
+        registration == other.registration &&
+        nav == other.nav &&
+        frame == other.frame &&
+        reactor == other.reactor &&
+        engine == other.engine &&
+        listsEqual(mounts, other.mounts);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship.dart
@@ -1,12 +1,15 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/scanned_ship_engine.dart';
 import 'package:spacetraders/model/scanned_ship_frame.dart';
 import 'package:spacetraders/model/scanned_ship_mounts_inner.dart';
 import 'package:spacetraders/model/scanned_ship_reactor.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 import 'package:spacetraders/model/ship_registration.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ScannedShip {
-  ScannedShip({
+  const ScannedShip({
     required this.symbol,
     required this.registration,
     required this.nav,

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_engine.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_engine.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ScannedShipEngine {
-  ScannedShipEngine({required this.symbol});
+  const ScannedShipEngine({required this.symbol});
 
   factory ScannedShipEngine.fromJson(Map<String, dynamic> json) {
     return ScannedShipEngine(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_engine.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_engine.dart
@@ -19,4 +19,13 @@ class ScannedShipEngine {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedShipEngine && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_frame.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_frame.dart
@@ -19,4 +19,13 @@ class ScannedShipFrame {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedShipFrame && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_frame.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_frame.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ScannedShipFrame {
-  ScannedShipFrame({required this.symbol});
+  const ScannedShipFrame({required this.symbol});
 
   factory ScannedShipFrame.fromJson(Map<String, dynamic> json) {
     return ScannedShipFrame(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_mounts_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_mounts_inner.dart
@@ -19,4 +19,13 @@ class ScannedShipMountsInner {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedShipMountsInner && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_mounts_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_mounts_inner.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ScannedShipMountsInner {
-  ScannedShipMountsInner({required this.symbol});
+  const ScannedShipMountsInner({required this.symbol});
 
   factory ScannedShipMountsInner.fromJson(Map<String, dynamic> json) {
     return ScannedShipMountsInner(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_reactor.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_reactor.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ScannedShipReactor {
-  ScannedShipReactor({required this.symbol});
+  const ScannedShipReactor({required this.symbol});
 
   factory ScannedShipReactor.fromJson(Map<String, dynamic> json) {
     return ScannedShipReactor(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/scanned_ship_reactor.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_ship_reactor.dart
@@ -19,4 +19,13 @@ class ScannedShipReactor {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedShipReactor && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_system.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_system.dart
@@ -47,4 +47,19 @@ class ScannedSystem {
       'distance': distance,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, sectorSymbol, type, x, y, distance);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedSystem &&
+        symbol == other.symbol &&
+        sectorSymbol == other.sectorSymbol &&
+        type == other.type &&
+        x == other.x &&
+        y == other.y &&
+        distance == other.distance;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scanned_system.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_system.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/system_type.dart';
 
+@immutable
 class ScannedSystem {
-  ScannedSystem({
+  const ScannedSystem({
     required this.symbol,
     required this.sectorSymbol,
     required this.type,

--- a/packages/gen/examples/spacetraders/lib/model/scanned_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_waypoint.dart
@@ -1,11 +1,14 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/chart.dart';
 import 'package:spacetraders/model/waypoint_faction.dart';
 import 'package:spacetraders/model/waypoint_orbital.dart';
 import 'package:spacetraders/model/waypoint_trait.dart';
 import 'package:spacetraders/model/waypoint_type.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ScannedWaypoint {
-  ScannedWaypoint({
+  const ScannedWaypoint({
     required this.symbol,
     required this.type,
     required this.systemSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/scanned_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scanned_waypoint.dart
@@ -75,4 +75,32 @@ class ScannedWaypoint {
       'chart': chart?.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    type,
+    systemSymbol,
+    x,
+    y,
+    orbitals,
+    faction,
+    traits,
+    chart,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScannedWaypoint &&
+        symbol == other.symbol &&
+        type == other.type &&
+        systemSymbol == other.systemSymbol &&
+        x == other.x &&
+        y == other.y &&
+        listsEqual(orbitals, other.orbitals) &&
+        faction == other.faction &&
+        listsEqual(traits, other.traits) &&
+        chart == other.chart;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/scrap_ship200_response_data.dart';
 
+@immutable
 class ScrapShip200Response {
-  ScrapShip200Response({required this.data});
+  const ScrapShip200Response({required this.data});
 
   factory ScrapShip200Response.fromJson(Map<String, dynamic> json) {
     return ScrapShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response.dart
@@ -25,4 +25,13 @@ class ScrapShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScrapShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response_data.dart
@@ -1,8 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/scrap_transaction.dart';
 
+@immutable
 class ScrapShip200ResponseData {
-  ScrapShip200ResponseData({required this.agent, required this.transaction});
+  const ScrapShip200ResponseData({
+    required this.agent,
+    required this.transaction,
+  });
 
   factory ScrapShip200ResponseData.fromJson(Map<String, dynamic> json) {
     return ScrapShip200ResponseData(

--- a/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_ship200_response_data.dart
@@ -28,4 +28,15 @@ class ScrapShip200ResponseData {
   Map<String, dynamic> toJson() {
     return {'agent': agent.toJson(), 'transaction': transaction.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(agent, transaction);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScrapShip200ResponseData &&
+        agent == other.agent &&
+        transaction == other.transaction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scrap_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_transaction.dart
@@ -37,4 +37,18 @@ class ScrapTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(waypointSymbol, shipSymbol, totalPrice, timestamp);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScrapTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        totalPrice == other.totalPrice &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/scrap_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/scrap_transaction.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ScrapTransaction {
-  ScrapTransaction({
+  const ScrapTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.totalPrice,

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response.dart
@@ -25,4 +25,13 @@ class SellCargo201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SellCargo201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/sell_cargo201_response_data.dart';
 
+@immutable
 class SellCargo201Response {
-  SellCargo201Response({required this.data});
+  const SellCargo201Response({required this.data});
 
   factory SellCargo201Response.fromJson(Map<String, dynamic> json) {
     return SellCargo201Response(

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response_data.dart
@@ -1,9 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/agent.dart';
 import 'package:spacetraders/model/market_transaction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class SellCargo201ResponseData {
-  SellCargo201ResponseData({
+  const SellCargo201ResponseData({
     required this.cargo,
     required this.transaction,
     required this.agent,

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo201_response_data.dart
@@ -39,4 +39,16 @@ class SellCargo201ResponseData {
       'agent': agent.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cargo, transaction, agent);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SellCargo201ResponseData &&
+        cargo == other.cargo &&
+        transaction == other.transaction &&
+        agent == other.agent;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo_request.dart
@@ -25,4 +25,15 @@ class SellCargoRequest {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SellCargoRequest &&
+        symbol == other.symbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/sell_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/sell_cargo_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class SellCargoRequest {
-  SellCargoRequest({required this.symbol, required this.units});
+  const SellCargoRequest({required this.symbol, required this.units});
 
   factory SellCargoRequest.fromJson(Map<String, dynamic> json) {
     return SellCargoRequest(

--- a/packages/gen/examples/spacetraders/lib/model/ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship.dart
@@ -93,4 +93,38 @@ class Ship {
       'cooldown': cooldown.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    registration,
+    nav,
+    crew,
+    frame,
+    reactor,
+    engine,
+    modules,
+    mounts,
+    cargo,
+    fuel,
+    cooldown,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Ship &&
+        symbol == other.symbol &&
+        registration == other.registration &&
+        nav == other.nav &&
+        crew == other.crew &&
+        frame == other.frame &&
+        reactor == other.reactor &&
+        engine == other.engine &&
+        listsEqual(modules, other.modules) &&
+        listsEqual(mounts, other.mounts) &&
+        cargo == other.cargo &&
+        fuel == other.fuel &&
+        cooldown == other.cooldown;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_crew.dart';
@@ -9,9 +10,11 @@ import 'package:spacetraders/model/ship_mount.dart';
 import 'package:spacetraders/model/ship_nav.dart';
 import 'package:spacetraders/model/ship_reactor.dart';
 import 'package:spacetraders/model/ship_registration.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Ship {
-  Ship({
+  const Ship({
     required this.symbol,
     required this.registration,
     required this.nav,

--- a/packages/gen/examples/spacetraders/lib/model/ship_cargo.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_cargo.dart
@@ -1,7 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_cargo_item.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ShipCargo {
-  ShipCargo({
+  const ShipCargo({
     required this.capacity,
     required this.units,
     this.inventory = const [],

--- a/packages/gen/examples/spacetraders/lib/model/ship_cargo.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_cargo.dart
@@ -40,4 +40,16 @@ class ShipCargo {
       'inventory': inventory.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(capacity, units, inventory);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipCargo &&
+        capacity == other.capacity &&
+        units == other.units &&
+        listsEqual(inventory, other.inventory);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_cargo_item.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_cargo_item.dart
@@ -39,4 +39,17 @@ class ShipCargoItem {
       'units': units,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, name, description, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipCargoItem &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_cargo_item.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_cargo_item.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class ShipCargoItem {
-  ShipCargoItem({
+  const ShipCargoItem({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/ship_condition_event.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_condition_event.dart
@@ -42,4 +42,17 @@ class ShipConditionEvent {
       'description': description,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, component, name, description);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipConditionEvent &&
+        symbol == other.symbol &&
+        component == other.component &&
+        name == other.name &&
+        description == other.description;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_condition_event.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_condition_event.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_condition_event_component.dart';
 import 'package:spacetraders/model/ship_condition_event_symbol.dart';
 
+@immutable
 class ShipConditionEvent {
-  ShipConditionEvent({
+  const ShipConditionEvent({
     required this.symbol,
     required this.component,
     required this.name,

--- a/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
@@ -13,7 +13,7 @@ class ShipCrew {
   factory ShipCrew.fromJson(Map<String, dynamic> json) {
     return ShipCrew(
       current: json['current'] as int,
-      required_: json['required'] as int,
+      required: json['required'] as int,
       capacity: json['capacity'] as int,
       rotation: ShipCrewRotation.fromJson(json['rotation'] as String),
       morale: json['morale'] as int,
@@ -40,11 +40,27 @@ class ShipCrew {
   Map<String, dynamic> toJson() {
     return {
       'current': current,
-      'required_': required_,
+      'required': required_,
       'capacity': capacity,
       'rotation': rotation.toJson(),
       'morale': morale,
       'wages': wages,
     };
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(current, required_, capacity, rotation, morale, wages);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipCrew &&
+        current == other.current &&
+        required_ == other.required_ &&
+        capacity == other.capacity &&
+        rotation == other.rotation &&
+        morale == other.morale &&
+        wages == other.wages;
   }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
@@ -13,7 +13,7 @@ class ShipCrew {
   factory ShipCrew.fromJson(Map<String, dynamic> json) {
     return ShipCrew(
       current: json['current'] as int,
-      required: json['required'] as int,
+      required_: json['required'] as int,
       capacity: json['capacity'] as int,
       rotation: ShipCrewRotation.fromJson(json['rotation'] as String),
       morale: json['morale'] as int,

--- a/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_crew.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_crew_rotation.dart';
 
+@immutable
 class ShipCrew {
-  ShipCrew({
+  const ShipCrew({
     required this.current,
     required this.required_,
     required this.capacity,

--- a/packages/gen/examples/spacetraders/lib/model/ship_engine.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_engine.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_engine_symbol.dart';
 import 'package:spacetraders/model/ship_requirements.dart';
 
+@immutable
 class ShipEngine {
-  ShipEngine({
+  const ShipEngine({
     required this.symbol,
     required this.name,
     required this.condition,

--- a/packages/gen/examples/spacetraders/lib/model/ship_engine.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_engine.dart
@@ -58,4 +58,30 @@ class ShipEngine {
       'quality': quality,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    name,
+    condition,
+    integrity,
+    description,
+    speed,
+    requirements,
+    quality,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipEngine &&
+        symbol == other.symbol &&
+        name == other.name &&
+        condition == other.condition &&
+        integrity == other.integrity &&
+        description == other.description &&
+        speed == other.speed &&
+        requirements == other.requirements &&
+        quality == other.quality;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_frame.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_frame.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_frame_symbol.dart';
 import 'package:spacetraders/model/ship_requirements.dart';
 
+@immutable
 class ShipFrame {
-  ShipFrame({
+  const ShipFrame({
     required this.symbol,
     required this.name,
     required this.condition,

--- a/packages/gen/examples/spacetraders/lib/model/ship_frame.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_frame.dart
@@ -66,4 +66,34 @@ class ShipFrame {
       'quality': quality,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    name,
+    condition,
+    integrity,
+    description,
+    moduleSlots,
+    mountingPoints,
+    fuelCapacity,
+    requirements,
+    quality,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipFrame &&
+        symbol == other.symbol &&
+        name == other.name &&
+        condition == other.condition &&
+        integrity == other.integrity &&
+        description == other.description &&
+        moduleSlots == other.moduleSlots &&
+        mountingPoints == other.mountingPoints &&
+        fuelCapacity == other.fuelCapacity &&
+        requirements == other.requirements &&
+        quality == other.quality;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_fuel.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_fuel.dart
@@ -33,4 +33,16 @@ class ShipFuel {
       'consumed': consumed?.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(current, capacity, consumed);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipFuel &&
+        current == other.current &&
+        capacity == other.capacity &&
+        consumed == other.consumed;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_fuel.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_fuel.dart
@@ -1,7 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_fuel_consumed.dart';
 
+@immutable
 class ShipFuel {
-  ShipFuel({required this.current, required this.capacity, this.consumed});
+  const ShipFuel({
+    required this.current,
+    required this.capacity,
+    this.consumed,
+  });
 
   factory ShipFuel.fromJson(Map<String, dynamic> json) {
     return ShipFuel(

--- a/packages/gen/examples/spacetraders/lib/model/ship_fuel_consumed.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_fuel_consumed.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ShipFuelConsumed {
-  ShipFuelConsumed({required this.amount, required this.timestamp});
+  const ShipFuelConsumed({required this.amount, required this.timestamp});
 
   factory ShipFuelConsumed.fromJson(Map<String, dynamic> json) {
     return ShipFuelConsumed(

--- a/packages/gen/examples/spacetraders/lib/model/ship_fuel_consumed.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_fuel_consumed.dart
@@ -23,4 +23,15 @@ class ShipFuelConsumed {
   Map<String, dynamic> toJson() {
     return {'amount': amount, 'timestamp': timestamp.toIso8601String()};
   }
+
+  @override
+  int get hashCode => Object.hash(amount, timestamp);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipFuelConsumed &&
+        amount == other.amount &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_modification_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_modification_transaction.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ShipModificationTransaction {
-  ShipModificationTransaction({
+  const ShipModificationTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.tradeSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/ship_modification_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_modification_transaction.dart
@@ -43,4 +43,24 @@ class ShipModificationTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    waypointSymbol,
+    shipSymbol,
+    tradeSymbol,
+    totalPrice,
+    timestamp,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipModificationTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        tradeSymbol == other.tradeSymbol &&
+        totalPrice == other.totalPrice &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_module.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_module.dart
@@ -50,4 +50,20 @@ class ShipModule {
       'requirements': requirements.toJson(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, name, description, capacity, range, requirements);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipModule &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description &&
+        capacity == other.capacity &&
+        range == other.range &&
+        requirements == other.requirements;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_module.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_module.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_module_symbol.dart';
 import 'package:spacetraders/model/ship_requirements.dart';
 
+@immutable
 class ShipModule {
-  ShipModule({
+  const ShipModule({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/ship_mount.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_mount.dart
@@ -52,4 +52,20 @@ class ShipMount {
       'requirements': requirements.toJson(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, name, description, strength, deposits, requirements);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipMount &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description &&
+        strength == other.strength &&
+        listsEqual(deposits, other.deposits) &&
+        requirements == other.requirements;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_mount.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_mount.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_mount_deposits_inner.dart';
 import 'package:spacetraders/model/ship_mount_symbol.dart';
 import 'package:spacetraders/model/ship_requirements.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ShipMount {
-  ShipMount({
+  const ShipMount({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav.dart
@@ -1,9 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav_flight_mode.dart';
 import 'package:spacetraders/model/ship_nav_route.dart';
 import 'package:spacetraders/model/ship_nav_status.dart';
 
+@immutable
 class ShipNav {
-  ShipNav({
+  const ShipNav({
     required this.systemSymbol,
     required this.waypointSymbol,
     required this.route,

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav.dart
@@ -45,4 +45,19 @@ class ShipNav {
       'flightMode': flightMode.toJson(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(systemSymbol, waypointSymbol, route, status, flightMode);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipNav &&
+        systemSymbol == other.systemSymbol &&
+        waypointSymbol == other.waypointSymbol &&
+        route == other.route &&
+        status == other.status &&
+        flightMode == other.flightMode;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav_route.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav_route.dart
@@ -43,4 +43,17 @@ class ShipNavRoute {
       'arrival': arrival.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(destination, origin, departureTime, arrival);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipNavRoute &&
+        destination == other.destination &&
+        origin == other.origin &&
+        departureTime == other.departureTime &&
+        arrival == other.arrival;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav_route.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav_route.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_nav_route_waypoint.dart';
 
+@immutable
 class ShipNavRoute {
-  ShipNavRoute({
+  const ShipNavRoute({
     required this.destination,
     required this.origin,
     required this.departureTime,

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav_route_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav_route_waypoint.dart
@@ -43,4 +43,18 @@ class ShipNavRouteWaypoint {
       'y': y,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, type, systemSymbol, x, y);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipNavRouteWaypoint &&
+        symbol == other.symbol &&
+        type == other.type &&
+        systemSymbol == other.systemSymbol &&
+        x == other.x &&
+        y == other.y;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_nav_route_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_nav_route_waypoint.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/waypoint_type.dart';
 
+@immutable
 class ShipNavRouteWaypoint {
-  ShipNavRouteWaypoint({
+  const ShipNavRouteWaypoint({
     required this.symbol,
     required this.type,
     required this.systemSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/ship_reactor.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_reactor.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_reactor_symbol.dart';
 import 'package:spacetraders/model/ship_requirements.dart';
 
+@immutable
 class ShipReactor {
-  ShipReactor({
+  const ShipReactor({
     required this.symbol,
     required this.name,
     required this.condition,

--- a/packages/gen/examples/spacetraders/lib/model/ship_reactor.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_reactor.dart
@@ -58,4 +58,30 @@ class ShipReactor {
       'quality': quality,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    name,
+    condition,
+    integrity,
+    description,
+    powerOutput,
+    requirements,
+    quality,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipReactor &&
+        symbol == other.symbol &&
+        name == other.name &&
+        condition == other.condition &&
+        integrity == other.integrity &&
+        description == other.description &&
+        powerOutput == other.powerOutput &&
+        requirements == other.requirements &&
+        quality == other.quality;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_refine201_response_data.dart';
 
+@immutable
 class ShipRefine201Response {
-  ShipRefine201Response({required this.data});
+  const ShipRefine201Response({required this.data});
 
   factory ShipRefine201Response.fromJson(Map<String, dynamic> json) {
     return ShipRefine201Response(

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response.dart
@@ -25,4 +25,13 @@ class ShipRefine201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRefine201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_refine201_response_data_consumed_inner.dart';
 import 'package:spacetraders/model/ship_refine201_response_data_produced_inner.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ShipRefine201ResponseData {
-  ShipRefine201ResponseData({
+  const ShipRefine201ResponseData({
     required this.cargo,
     required this.cooldown,
     this.produced = const [],

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data.dart
@@ -56,4 +56,17 @@ class ShipRefine201ResponseData {
       'consumed': consumed.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(cargo, cooldown, produced, consumed);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRefine201ResponseData &&
+        cargo == other.cargo &&
+        cooldown == other.cooldown &&
+        listsEqual(produced, other.produced) &&
+        listsEqual(consumed, other.consumed);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_consumed_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_consumed_inner.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class ShipRefine201ResponseDataConsumedInner {
-  ShipRefine201ResponseDataConsumedInner({
+  const ShipRefine201ResponseDataConsumedInner({
     required this.tradeSymbol,
     required this.units,
   });

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_consumed_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_consumed_inner.dart
@@ -32,4 +32,15 @@ class ShipRefine201ResponseDataConsumedInner {
   Map<String, dynamic> toJson() {
     return {'tradeSymbol': tradeSymbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(tradeSymbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRefine201ResponseDataConsumedInner &&
+        tradeSymbol == other.tradeSymbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_produced_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_produced_inner.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class ShipRefine201ResponseDataProducedInner {
-  ShipRefine201ResponseDataProducedInner({
+  const ShipRefine201ResponseDataProducedInner({
     required this.tradeSymbol,
     required this.units,
   });

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_produced_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine201_response_data_produced_inner.dart
@@ -32,4 +32,15 @@ class ShipRefine201ResponseDataProducedInner {
   Map<String, dynamic> toJson() {
     return {'tradeSymbol': tradeSymbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(tradeSymbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRefine201ResponseDataProducedInner &&
+        tradeSymbol == other.tradeSymbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_refine_request_produce.dart';
 
+@immutable
 class ShipRefineRequest {
-  ShipRefineRequest({required this.produce});
+  const ShipRefineRequest({required this.produce});
 
   factory ShipRefineRequest.fromJson(Map<String, dynamic> json) {
     return ShipRefineRequest(

--- a/packages/gen/examples/spacetraders/lib/model/ship_refine_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_refine_request.dart
@@ -23,4 +23,13 @@ class ShipRefineRequest {
   Map<String, dynamic> toJson() {
     return {'produce': produce.toJson()};
   }
+
+  @override
+  int get hashCode => produce.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRefineRequest && produce == other.produce;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_registration.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_registration.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_role.dart';
 
+@immutable
 class ShipRegistration {
-  ShipRegistration({
+  const ShipRegistration({
     required this.name,
     required this.factionSymbol,
     required this.role,

--- a/packages/gen/examples/spacetraders/lib/model/ship_registration.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_registration.dart
@@ -35,4 +35,16 @@ class ShipRegistration {
       'role': role.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(name, factionSymbol, role);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRegistration &&
+        name == other.name &&
+        factionSymbol == other.factionSymbol &&
+        role == other.role;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_requirements.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_requirements.dart
@@ -25,4 +25,16 @@ class ShipRequirements {
   Map<String, dynamic> toJson() {
     return {'power': power, 'crew': crew, 'slots': slots};
   }
+
+  @override
+  int get hashCode => Object.hash(power, crew, slots);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipRequirements &&
+        power == other.power &&
+        crew == other.crew &&
+        slots == other.slots;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/ship_requirements.dart
+++ b/packages/gen/examples/spacetraders/lib/model/ship_requirements.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ShipRequirements {
-  ShipRequirements({this.power, this.crew, this.slots});
+  const ShipRequirements({this.power, this.crew, this.slots});
 
   factory ShipRequirements.fromJson(Map<String, dynamic> json) {
     return ShipRequirements(

--- a/packages/gen/examples/spacetraders/lib/model/shipyard.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard.dart
@@ -61,4 +61,19 @@ class Shipyard {
       'modificationsFee': modificationsFee,
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(symbol, shipTypes, transactions, ships, modificationsFee);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Shipyard &&
+        symbol == other.symbol &&
+        listsEqual(shipTypes, other.shipTypes) &&
+        listsEqual(transactions, other.transactions) &&
+        listsEqual(ships, other.ships) &&
+        modificationsFee == other.modificationsFee;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/shipyard_ship.dart';
 import 'package:spacetraders/model/shipyard_ship_types_inner.dart';
 import 'package:spacetraders/model/shipyard_transaction.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Shipyard {
-  Shipyard({
+  const Shipyard({
     required this.symbol,
     required this.modificationsFee,
     this.shipTypes = const [],

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship.dart
@@ -89,4 +89,38 @@ class ShipyardShip {
       'crew': crew.toJson(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    name,
+    description,
+    activity,
+    supply,
+    purchasePrice,
+    frame,
+    reactor,
+    engine,
+    modules,
+    mounts,
+    crew,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipyardShip &&
+        type == other.type &&
+        name == other.name &&
+        description == other.description &&
+        activity == other.activity &&
+        supply == other.supply &&
+        purchasePrice == other.purchasePrice &&
+        frame == other.frame &&
+        reactor == other.reactor &&
+        engine == other.engine &&
+        listsEqual(modules, other.modules) &&
+        listsEqual(mounts, other.mounts) &&
+        crew == other.crew;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/activity_level.dart';
 import 'package:spacetraders/model/ship_engine.dart';
 import 'package:spacetraders/model/ship_frame.dart';
@@ -7,9 +8,11 @@ import 'package:spacetraders/model/ship_reactor.dart';
 import 'package:spacetraders/model/ship_type.dart';
 import 'package:spacetraders/model/shipyard_ship_crew.dart';
 import 'package:spacetraders/model/supply_level.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class ShipyardShip {
-  ShipyardShip({
+  const ShipyardShip({
     required this.type,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ShipyardShipCrew {
-  ShipyardShipCrew({required this.required_, required this.capacity});
+  const ShipyardShipCrew({required this.required_, required this.capacity});
 
   factory ShipyardShipCrew.fromJson(Map<String, dynamic> json) {
     return ShipyardShipCrew(

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
@@ -3,7 +3,7 @@ class ShipyardShipCrew {
 
   factory ShipyardShipCrew.fromJson(Map<String, dynamic> json) {
     return ShipyardShipCrew(
-      required_: json['required'] as int,
+      required: json['required'] as int,
       capacity: json['capacity'] as int,
     );
   }
@@ -21,6 +21,17 @@ class ShipyardShipCrew {
   final int capacity;
 
   Map<String, dynamic> toJson() {
-    return {'required_': required_, 'capacity': capacity};
+    return {'required': required_, 'capacity': capacity};
+  }
+
+  @override
+  int get hashCode => Object.hash(required_, capacity);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipyardShipCrew &&
+        required_ == other.required_ &&
+        capacity == other.capacity;
   }
 }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship_crew.dart
@@ -3,7 +3,7 @@ class ShipyardShipCrew {
 
   factory ShipyardShipCrew.fromJson(Map<String, dynamic> json) {
     return ShipyardShipCrew(
-      required: json['required'] as int,
+      required_: json['required'] as int,
       capacity: json['capacity'] as int,
     );
   }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship_types_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship_types_inner.dart
@@ -23,4 +23,13 @@ class ShipyardShipTypesInner {
   Map<String, dynamic> toJson() {
     return {'type': type.toJson()};
   }
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipyardShipTypesInner && type == other.type;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_ship_types_inner.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_ship_types_inner.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_type.dart';
 
+@immutable
 class ShipyardShipTypesInner {
-  ShipyardShipTypesInner({required this.type});
+  const ShipyardShipTypesInner({required this.type});
 
   factory ShipyardShipTypesInner.fromJson(Map<String, dynamic> json) {
     return ShipyardShipTypesInner(

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_transaction.dart
@@ -45,4 +45,26 @@ class ShipyardTransaction {
       'timestamp': timestamp.toIso8601String(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    waypointSymbol,
+    shipSymbol,
+    shipType,
+    price,
+    agentSymbol,
+    timestamp,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShipyardTransaction &&
+        waypointSymbol == other.waypointSymbol &&
+        shipSymbol == other.shipSymbol &&
+        shipType == other.shipType &&
+        price == other.price &&
+        agentSymbol == other.agentSymbol &&
+        timestamp == other.timestamp;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/shipyard_transaction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/shipyard_transaction.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class ShipyardTransaction {
-  ShipyardTransaction({
+  const ShipyardTransaction({
     required this.waypointSymbol,
     required this.shipSymbol,
     required this.shipType,

--- a/packages/gen/examples/spacetraders/lib/model/siphon.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon.dart
@@ -6,7 +6,7 @@ class Siphon {
   factory Siphon.fromJson(Map<String, dynamic> json) {
     return Siphon(
       shipSymbol: json['shipSymbol'] as String,
-      yield_: SiphonYield.fromJson(json['yield'] as Map<String, dynamic>),
+      yield: SiphonYield.fromJson(json['yield'] as Map<String, dynamic>),
     );
   }
 
@@ -23,6 +23,17 @@ class Siphon {
   final SiphonYield yield_;
 
   Map<String, dynamic> toJson() {
-    return {'shipSymbol': shipSymbol, 'yield_': yield_.toJson()};
+    return {'shipSymbol': shipSymbol, 'yield': yield_.toJson()};
+  }
+
+  @override
+  int get hashCode => Object.hash(shipSymbol, yield_);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Siphon &&
+        shipSymbol == other.shipSymbol &&
+        yield_ == other.yield_;
   }
 }

--- a/packages/gen/examples/spacetraders/lib/model/siphon.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/siphon_yield.dart';
 
+@immutable
 class Siphon {
-  Siphon({required this.shipSymbol, required this.yield_});
+  const Siphon({required this.shipSymbol, required this.yield_});
 
   factory Siphon.fromJson(Map<String, dynamic> json) {
     return Siphon(

--- a/packages/gen/examples/spacetraders/lib/model/siphon.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon.dart
@@ -6,7 +6,7 @@ class Siphon {
   factory Siphon.fromJson(Map<String, dynamic> json) {
     return Siphon(
       shipSymbol: json['shipSymbol'] as String,
-      yield: SiphonYield.fromJson(json['yield'] as Map<String, dynamic>),
+      yield_: SiphonYield.fromJson(json['yield'] as Map<String, dynamic>),
     );
   }
 

--- a/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response.dart
@@ -25,4 +25,13 @@ class SiphonResources201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SiphonResources201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/siphon_resources201_response_data.dart';
 
+@immutable
 class SiphonResources201Response {
-  SiphonResources201Response({required this.data});
+  const SiphonResources201Response({required this.data});
 
   factory SiphonResources201Response.fromJson(Map<String, dynamic> json) {
     return SiphonResources201Response(

--- a/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response_data.dart
@@ -49,4 +49,17 @@ class SiphonResources201ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(siphon, cooldown, cargo, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SiphonResources201ResponseData &&
+        siphon == other.siphon &&
+        cooldown == other.cooldown &&
+        cargo == other.cargo &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_resources201_response_data.dart
@@ -1,10 +1,13 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/cooldown.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/siphon.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class SiphonResources201ResponseData {
-  SiphonResources201ResponseData({
+  const SiphonResources201ResponseData({
     required this.siphon,
     required this.cooldown,
     required this.cargo,

--- a/packages/gen/examples/spacetraders/lib/model/siphon_yield.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_yield.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class SiphonYield {
-  SiphonYield({required this.symbol, required this.units});
+  const SiphonYield({required this.symbol, required this.units});
 
   factory SiphonYield.fromJson(Map<String, dynamic> json) {
     return SiphonYield(

--- a/packages/gen/examples/spacetraders/lib/model/siphon_yield.dart
+++ b/packages/gen/examples/spacetraders/lib/model/siphon_yield.dart
@@ -25,4 +25,15 @@ class SiphonYield {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson(), 'units': units};
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SiphonYield &&
+        symbol == other.symbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction201_response.dart
@@ -27,4 +27,13 @@ class SupplyConstruction201Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SupplyConstruction201Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction201_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction201_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/supply_construction201_response_data.dart';
 
+@immutable
 class SupplyConstruction201Response {
-  SupplyConstruction201Response({required this.data});
+  const SupplyConstruction201Response({required this.data});
 
   factory SupplyConstruction201Response.fromJson(Map<String, dynamic> json) {
     return SupplyConstruction201Response(

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction201_response_data.dart
@@ -35,4 +35,15 @@ class SupplyConstruction201ResponseData {
   Map<String, dynamic> toJson() {
     return {'construction': construction.toJson(), 'cargo': cargo.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(construction, cargo);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SupplyConstruction201ResponseData &&
+        construction == other.construction &&
+        cargo == other.cargo;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction201_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction201_response_data.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/construction.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class SupplyConstruction201ResponseData {
-  SupplyConstruction201ResponseData({
+  const SupplyConstruction201ResponseData({
     required this.construction,
     required this.cargo,
   });

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction_request.dart
@@ -35,4 +35,16 @@ class SupplyConstructionRequest {
       'units': units,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(shipSymbol, tradeSymbol, units);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SupplyConstructionRequest &&
+        shipSymbol == other.shipSymbol &&
+        tradeSymbol == other.tradeSymbol &&
+        units == other.units;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/supply_construction_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/supply_construction_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class SupplyConstructionRequest {
-  SupplyConstructionRequest({
+  const SupplyConstructionRequest({
     required this.shipSymbol,
     required this.tradeSymbol,
     required this.units,

--- a/packages/gen/examples/spacetraders/lib/model/survey.dart
+++ b/packages/gen/examples/spacetraders/lib/model/survey.dart
@@ -49,4 +49,19 @@ class Survey {
       'size': size.toJson(),
     };
   }
+
+  @override
+  int get hashCode =>
+      Object.hash(signature, symbol, deposits, expiration, size);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Survey &&
+        signature == other.signature &&
+        symbol == other.symbol &&
+        listsEqual(deposits, other.deposits) &&
+        expiration == other.expiration &&
+        size == other.size;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/survey.dart
+++ b/packages/gen/examples/spacetraders/lib/model/survey.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/survey_deposit.dart';
 import 'package:spacetraders/model/survey_size.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Survey {
-  Survey({
+  const Survey({
     required this.signature,
     required this.symbol,
     required this.expiration,

--- a/packages/gen/examples/spacetraders/lib/model/survey_deposit.dart
+++ b/packages/gen/examples/spacetraders/lib/model/survey_deposit.dart
@@ -23,4 +23,13 @@ class SurveyDeposit {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson()};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SurveyDeposit && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/survey_deposit.dart
+++ b/packages/gen/examples/spacetraders/lib/model/survey_deposit.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class SurveyDeposit {
-  SurveyDeposit({required this.symbol});
+  const SurveyDeposit({required this.symbol});
 
   factory SurveyDeposit.fromJson(Map<String, dynamic> json) {
     return SurveyDeposit(

--- a/packages/gen/examples/spacetraders/lib/model/system.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system.dart
@@ -71,4 +71,32 @@ class System {
       'name': name,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    constellation,
+    symbol,
+    sectorSymbol,
+    type,
+    x,
+    y,
+    waypoints,
+    factions,
+    name,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is System &&
+        constellation == other.constellation &&
+        symbol == other.symbol &&
+        sectorSymbol == other.sectorSymbol &&
+        type == other.type &&
+        x == other.x &&
+        y == other.y &&
+        listsEqual(waypoints, other.waypoints) &&
+        listsEqual(factions, other.factions) &&
+        name == other.name;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/system.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/system_faction.dart';
 import 'package:spacetraders/model/system_type.dart';
 import 'package:spacetraders/model/system_waypoint.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class System {
-  System({
+  const System({
     required this.symbol,
     required this.sectorSymbol,
     required this.type,

--- a/packages/gen/examples/spacetraders/lib/model/system_faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system_faction.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction_symbol.dart';
 
+@immutable
 class SystemFaction {
-  SystemFaction({required this.symbol});
+  const SystemFaction({required this.symbol});
 
   factory SystemFaction.fromJson(Map<String, dynamic> json) {
     return SystemFaction(

--- a/packages/gen/examples/spacetraders/lib/model/system_faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system_faction.dart
@@ -23,4 +23,13 @@ class SystemFaction {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson()};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SystemFaction && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/system_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system_waypoint.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/waypoint_orbital.dart';
 import 'package:spacetraders/model/waypoint_type.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class SystemWaypoint {
-  SystemWaypoint({
+  const SystemWaypoint({
     required this.symbol,
     required this.type,
     required this.x,

--- a/packages/gen/examples/spacetraders/lib/model/system_waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/system_waypoint.dart
@@ -53,4 +53,19 @@ class SystemWaypoint {
       'orbits': orbits,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, type, x, y, orbitals, orbits);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SystemWaypoint &&
+        symbol == other.symbol &&
+        type == other.type &&
+        x == other.x &&
+        y == other.y &&
+        listsEqual(orbitals, other.orbitals) &&
+        orbits == other.orbits;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/trade_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/trade_good.dart
@@ -35,4 +35,16 @@ class TradeGood {
       'description': description,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, name, description);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TradeGood &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/trade_good.dart
+++ b/packages/gen/examples/spacetraders/lib/model/trade_good.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class TradeGood {
-  TradeGood({
+  const TradeGood({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/transfer_cargo200_response_data.dart';
 
+@immutable
 class TransferCargo200Response {
-  TransferCargo200Response({required this.data});
+  const TransferCargo200Response({required this.data});
 
   factory TransferCargo200Response.fromJson(Map<String, dynamic> json) {
     return TransferCargo200Response(

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response.dart
@@ -25,4 +25,13 @@ class TransferCargo200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TransferCargo200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response_data.dart
@@ -32,4 +32,15 @@ class TransferCargo200ResponseData {
   Map<String, dynamic> toJson() {
     return {'cargo': cargo.toJson(), 'targetCargo': targetCargo.toJson()};
   }
+
+  @override
+  int get hashCode => Object.hash(cargo, targetCargo);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TransferCargo200ResponseData &&
+        cargo == other.cargo &&
+        targetCargo == other.targetCargo;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo200_response_data.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_cargo.dart';
 
+@immutable
 class TransferCargo200ResponseData {
-  TransferCargo200ResponseData({
+  const TransferCargo200ResponseData({
     required this.cargo,
     required this.targetCargo,
   });

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo_request.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/trade_symbol.dart';
 
+@immutable
 class TransferCargoRequest {
-  TransferCargoRequest({
+  const TransferCargoRequest({
     required this.tradeSymbol,
     required this.units,
     required this.shipSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/transfer_cargo_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/transfer_cargo_request.dart
@@ -35,4 +35,16 @@ class TransferCargoRequest {
       'shipSymbol': shipSymbol,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(tradeSymbol, units, shipSymbol);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TransferCargoRequest &&
+        tradeSymbol == other.tradeSymbol &&
+        units == other.units &&
+        shipSymbol == other.shipSymbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship200_response.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/warp_ship200_response_data.dart';
 
+@immutable
 class WarpShip200Response {
-  WarpShip200Response({required this.data});
+  const WarpShip200Response({required this.data});
 
   factory WarpShip200Response.fromJson(Map<String, dynamic> json) {
     return WarpShip200Response(

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship200_response.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship200_response.dart
@@ -25,4 +25,13 @@ class WarpShip200Response {
   Map<String, dynamic> toJson() {
     return {'data': data.toJson()};
   }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WarpShip200Response && data == other.data;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship200_response_data.dart
@@ -42,4 +42,16 @@ class WarpShip200ResponseData {
       'events': events.map((e) => e.toJson()).toList(),
     };
   }
+
+  @override
+  int get hashCode => Object.hash(nav, fuel, events);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WarpShip200ResponseData &&
+        nav == other.nav &&
+        fuel == other.fuel &&
+        listsEqual(events, other.events);
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship200_response_data.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship200_response_data.dart
@@ -1,9 +1,12 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/ship_condition_event.dart';
 import 'package:spacetraders/model/ship_fuel.dart';
 import 'package:spacetraders/model/ship_nav.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class WarpShip200ResponseData {
-  WarpShip200ResponseData({
+  const WarpShip200ResponseData({
     required this.nav,
     required this.fuel,
     this.events = const [],

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship_request.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class WarpShipRequest {
-  WarpShipRequest({required this.waypointSymbol});
+  const WarpShipRequest({required this.waypointSymbol});
 
   factory WarpShipRequest.fromJson(Map<String, dynamic> json) {
     return WarpShipRequest(waypointSymbol: json['waypointSymbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/warp_ship_request.dart
+++ b/packages/gen/examples/spacetraders/lib/model/warp_ship_request.dart
@@ -19,4 +19,13 @@ class WarpShipRequest {
   Map<String, dynamic> toJson() {
     return {'waypointSymbol': waypointSymbol};
   }
+
+  @override
+  int get hashCode => waypointSymbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WarpShipRequest && waypointSymbol == other.waypointSymbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint.dart
@@ -93,4 +93,38 @@ class Waypoint {
       'isUnderConstruction': isUnderConstruction,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(
+    symbol,
+    type,
+    systemSymbol,
+    x,
+    y,
+    orbitals,
+    orbits,
+    faction,
+    traits,
+    modifiers,
+    chart,
+    isUnderConstruction,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Waypoint &&
+        symbol == other.symbol &&
+        type == other.type &&
+        systemSymbol == other.systemSymbol &&
+        x == other.x &&
+        y == other.y &&
+        listsEqual(orbitals, other.orbitals) &&
+        orbits == other.orbits &&
+        faction == other.faction &&
+        listsEqual(traits, other.traits) &&
+        listsEqual(modifiers, other.modifiers) &&
+        chart == other.chart &&
+        isUnderConstruction == other.isUnderConstruction;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint.dart
@@ -1,12 +1,15 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/chart.dart';
 import 'package:spacetraders/model/waypoint_faction.dart';
 import 'package:spacetraders/model/waypoint_modifier.dart';
 import 'package:spacetraders/model/waypoint_orbital.dart';
 import 'package:spacetraders/model/waypoint_trait.dart';
 import 'package:spacetraders/model/waypoint_type.dart';
+import 'package:spacetraders/model_helpers.dart';
 
+@immutable
 class Waypoint {
-  Waypoint({
+  const Waypoint({
     required this.symbol,
     required this.type,
     required this.systemSymbol,

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_faction.dart
@@ -23,4 +23,13 @@ class WaypointFaction {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol.toJson()};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WaypointFaction && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_faction.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_faction.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/faction_symbol.dart';
 
+@immutable
 class WaypointFaction {
-  WaypointFaction({required this.symbol});
+  const WaypointFaction({required this.symbol});
 
   factory WaypointFaction.fromJson(Map<String, dynamic> json) {
     return WaypointFaction(

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_modifier.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_modifier.dart
@@ -35,4 +35,16 @@ class WaypointModifier {
       'description': description,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, name, description);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WaypointModifier &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_modifier.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_modifier.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/waypoint_modifier_symbol.dart';
 
+@immutable
 class WaypointModifier {
-  WaypointModifier({
+  const WaypointModifier({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_orbital.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_orbital.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class WaypointOrbital {
-  WaypointOrbital({required this.symbol});
+  const WaypointOrbital({required this.symbol});
 
   factory WaypointOrbital.fromJson(Map<String, dynamic> json) {
     return WaypointOrbital(symbol: json['symbol'] as String);

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_orbital.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_orbital.dart
@@ -19,4 +19,13 @@ class WaypointOrbital {
   Map<String, dynamic> toJson() {
     return {'symbol': symbol};
   }
+
+  @override
+  int get hashCode => symbol.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WaypointOrbital && symbol == other.symbol;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_trait.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_trait.dart
@@ -35,4 +35,16 @@ class WaypointTrait {
       'description': description,
     };
   }
+
+  @override
+  int get hashCode => Object.hash(symbol, name, description);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WaypointTrait &&
+        symbol == other.symbol &&
+        name == other.name &&
+        description == other.description;
+  }
 }

--- a/packages/gen/examples/spacetraders/lib/model/waypoint_trait.dart
+++ b/packages/gen/examples/spacetraders/lib/model/waypoint_trait.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:spacetraders/model/waypoint_trait_symbol.dart';
 
+@immutable
 class WaypointTrait {
-  WaypointTrait({
+  const WaypointTrait({
     required this.symbol,
     required this.name,
     required this.description,

--- a/packages/gen/examples/spacetraders/lib/model_helpers.dart
+++ b/packages/gen/examples/spacetraders/lib/model_helpers.dart
@@ -1,0 +1,11 @@
+import 'package:collection/collection.dart';
+
+bool listsEqual<T>(List<T>? a, List<T>? b) {
+  final deepEquals = const DeepCollectionEquality().equals;
+  return deepEquals(a, b);
+}
+
+bool mapsEqual<K, V>(Map<K, V>? a, Map<K, V>? b) {
+  final deepEquals = const DeepCollectionEquality().equals;
+  return deepEquals(a, b);
+}

--- a/packages/gen/examples/spacetraders/pubspec.yaml
+++ b/packages/gen/examples/spacetraders/pubspec.yaml
@@ -6,9 +6,10 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
+  collection: ^1.19.0
   http: ^1.4.0
+  meta: ^1.17.0
 
-  meta: any
 dev_dependencies:
   test: ^1.26.0
   very_good_analysis: ^7.0.0

--- a/packages/gen/lib/src/context.dart
+++ b/packages/gen/lib/src/context.dart
@@ -709,6 +709,10 @@ class _Context {
       outPath: 'lib/api_client.dart',
       context: {'baseUri': spec.serverUrl, 'packageName': packageName},
     );
+    _renderTemplate(
+      template: 'model_helpers',
+      outPath: 'lib/model_helpers.dart',
+    );
   }
 
   /// Run a dart command.
@@ -916,6 +920,8 @@ _RenderContext _renderSchema(_Context context, Schema schema) {
     case SchemaRenderType.pod:
       throw StateError('Pod schemas should not be rendered: $schema');
   }
+
+  imports.add('package:${context.packageName}/model_helpers.dart');
 
   final outPath = Paths.modelFilePath(schema);
   logger.detail('rendering $outPath from ${schema.pointer}');

--- a/packages/gen/lib/templates/model_helpers.mustache
+++ b/packages/gen/lib/templates/model_helpers.mustache
@@ -1,0 +1,11 @@
+import 'package:collection/collection.dart';
+
+bool listsEqual<T>(List<T>? a, List<T>? b) {
+  final deepEquals = const DeepCollectionEquality().equals;
+  return deepEquals(a, b);
+}
+
+bool mapsEqual<K, V>(Map<K, V>? a, Map<K, V>? b) {
+  final deepEquals = const DeepCollectionEquality().equals;
+  return deepEquals(a, b);
+}

--- a/packages/gen/lib/templates/pubspec.mustache
+++ b/packages/gen/lib/templates/pubspec.mustache
@@ -6,7 +6,9 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
+  collection: ^1.19.0
   http: ^1.4.0
+  meta: ^1.17.0
 
 dev_dependencies:
   test: ^1.26.0

--- a/packages/gen/lib/templates/schema_object.mustache
+++ b/packages/gen/lib/templates/schema_object.mustache
@@ -5,7 +5,7 @@ import '{{{.}}}';
 class {{ typeName }} {
     {{ typeName }}(
         {{#hasProperties}}
-        { {{#properties}}{{#useRequired}}required{{/useRequired}} this.{{{ name }}}{{#hasDefaultValue}} = {{{ defaultValue }}}{{/hasDefaultValue}},{{/properties}}
+        { {{#properties}}{{#useRequired}}required{{/useRequired}} this.{{{ dartName }}}{{#hasDefaultValue}} = {{{ defaultValue }}}{{/hasDefaultValue}},{{/properties}}
         {{#hasAdditionalProperties}}required this.{{additionalPropertiesName}},{{/hasAdditionalProperties}} }
         {{/hasProperties}}
     );
@@ -20,7 +20,7 @@ class {{ typeName }} {
     {{/castFromJsonArg}}
         return {{ typeName }}(
             {{#properties}}
-            {{ name }}: {{{ fromJson }}},
+            {{ jsonName }}: {{{ fromJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
             {{additionalPropertiesName}}: json.map((key, value) => MapEntry(key, {{{ valueFromJson }}})),
@@ -37,11 +37,7 @@ class {{ typeName }} {
         return {{ typeName }}.fromJson(json);
     }
 
-    {{#properties}}
-    {{^mutableModels}}final{{/mutableModels}}
-    {{^isNullable}}{{{ type }}}{{/isNullable}}
-    {{#isNullable}}{{{ nullableType }}}{{/isNullable}} {{ name }};
-    {{/properties}}
+    {{#properties}}{{^mutableModels}}final{{/mutableModels}} {{^isNullable}}{{{ type }}}{{/isNullable}} {{#isNullable}}{{{ nullableType }}}{{/isNullable}} {{ dartName }};{{/properties}}
 
     {{#hasAdditionalProperties}}
     final Map<String, {{{ valueSchema }}}> {{additionalPropertiesName}};
@@ -52,11 +48,45 @@ class {{ typeName }} {
     Map<String, dynamic> toJson() {
         return {
             {{#properties}}
-            '{{ name }}': {{{ toJson }}},
+            '{{ jsonName }}': {{{ toJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
             ...{{additionalPropertiesName}}.map((key, value) => MapEntry(key, {{{ valueToJson }}})),
             {{/hasAdditionalProperties}}
         };
+    }
+
+    @override
+    int get hashCode =>
+        {{#hasOneProperty}}
+          {{#properties}}
+          {{ dartName }}.hashCode;
+          {{/properties}}
+          {{#hasAdditionalProperties}}
+          {{additionalPropertiesName}}.hashCode;
+          {{/hasAdditionalProperties}}
+        {{/hasOneProperty}}
+        {{^hasOneProperty}}
+        Object.hash(
+          {{#properties}}
+          {{ dartName }},
+          {{/properties}}
+          {{#hasAdditionalProperties}}
+          {{additionalPropertiesName}},
+          {{/hasAdditionalProperties}}
+        );
+        {{/hasOneProperty}}
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{ typeName }}
+            {{#properties}}
+            && {{ equals}}
+            {{/properties}}
+            {{#hasAdditionalProperties}}
+            && mapsEqual({{additionalPropertiesName}}, other.{{additionalPropertiesName}})
+            {{/hasAdditionalProperties}}
+        ;
     }
 }

--- a/packages/gen/lib/templates/schema_object.mustache
+++ b/packages/gen/lib/templates/schema_object.mustache
@@ -2,6 +2,11 @@
 import '{{{.}}}';
 {{/imports}}
 
+{{^mutableModels}}
+import 'package:meta/meta.dart';
+
+@immutable
+{{/mutableModels}}
 class {{ typeName }} {
     {{ typeName }}(
         {{#hasProperties}}

--- a/packages/gen/lib/templates/schema_object.mustache
+++ b/packages/gen/lib/templates/schema_object.mustache
@@ -20,7 +20,7 @@ class {{ typeName }} {
     {{/castFromJsonArg}}
         return {{ typeName }}(
             {{#properties}}
-            {{ jsonName }}: {{{ fromJson }}},
+            {{ dartName }}: {{{ fromJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
             {{additionalPropertiesName}}: json.map((key, value) => MapEntry(key, {{{ valueFromJson }}})),

--- a/packages/gen/test/render_test.dart
+++ b/packages/gen/test/render_test.dart
@@ -34,6 +34,20 @@ class _Exists extends Matcher {
 
 const exists = _Exists();
 
+class _HasFiles extends CustomMatcher {
+  _HasFiles(List<String> files) : super('has files', 'files', files);
+
+  @override
+  Object? featureValueOf(dynamic actual) {
+    return (actual as Directory)
+        .listSync()
+        .map((e) => e.path.split('/').last)
+        .toList();
+  }
+}
+
+Matcher hasFiles(List<String> files) => _HasFiles(files);
+
 void main() {
   group('loadAndRenderSpec', () {
     const localFs = LocalFileSystem();
@@ -284,8 +298,6 @@ void main() {
       final logger = _MockLogger();
 
       File outFile(String path) => out.childFile(path);
-      File modelFile(String path) =>
-          out.childDirectory('lib/model').childFile(path);
       File apiFile(String path) =>
           out.childDirectory('lib/api').childFile(path);
 
@@ -294,10 +306,15 @@ void main() {
       expect(outFile('lib/api.dart'), exists);
       expect(outFile('lib/api_client.dart'), exists);
       expect(apiFile('fleet_api.dart'), exists);
-      expect(modelFile('purchase_cargo201_response.dart'), exists);
-      expect(modelFile('purchase_cargo201_response_data.dart'), exists);
-      expect(modelFile('purchase_cargo201_response_data_cargo.dart'), exists);
-      expect(modelFile('purchase_cargo_request.dart'), exists);
+      expect(
+        out.childDirectory('lib/model'),
+        hasFiles([
+          'purchase_cargo201_response.dart',
+          'purchase_cargo201_response_data.dart',
+          'purchase_cargo201_response_data_cargo.dart',
+          'purchase_cargo_request.dart',
+        ]),
+      );
     });
 
     test('with newtype', () async {
@@ -501,11 +518,9 @@ void main() {
       final logger = _MockLogger();
 
       await renderToDirectory(spec: spec, outDir: out, logger: logger);
-      final modelPaths = out.childDirectory('lib/model').listSync();
-      expect(modelPaths, hasLength(2));
       expect(
-        modelPaths.map((e) => e.path.split('/').last),
-        containsAll([
+        out.childDirectory('lib/model'),
+        hasFiles([
           'get_my_factions200_response.dart',
           'get_my_factions200_response_data_inner.dart',
         ]),
@@ -557,6 +572,37 @@ void main() {
         isNot(exists),
       );
       expect(out.childFile('lib/api/default_api.dart'), exists);
+    });
+
+    test('with boolean', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'operationId': 'get-user',
+              'responses': {
+                '200': {
+                  'description': 'Default Response',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'boolean'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      final out = fs.directory('spacetraders');
+      final logger = _MockLogger();
+
+      await renderToDirectory(spec: spec, outDir: out, logger: logger);
+      expect(out.childDirectory('lib/api'), hasFiles(['default_api.dart']));
     });
   });
 }


### PR DESCRIPTION
Previously when we were avoiding dart keywords (e.g. yield) by re-writing to "yield_" we were also storing back to json as "yield_" which broke round tripping.