### PR TITLE
refactor: merge Json and ParseContext

### DIFF
--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -216,13 +216,13 @@ SchemaRef parseSchemaOrRef(MapContext json) {
 
   if (json.containsKey('oneOf')) {
     // TODO(eseidel): Support oneOf
-    _unimplemented(json, 'OneOf');
+    _unimplemented(json, 'oneOf');
   }
 
   if (json.containsKey('allOf')) {
     final allOf = json.childAsList('allOf');
     if (allOf.length != 1) {
-      _unimplemented(json, 'AllOf with ${allOf.length} items');
+      _unimplemented(json, 'allOf with ${allOf.length} items');
     }
     return parseSchemaOrRef(allOf.indexAsMap(0));
   }
@@ -258,7 +258,7 @@ SchemaRef parseSchemaOrRef(MapContext json) {
       }
     }
 
-    _unimplemented(json, 'AnyOf with ${anyOf.length} items');
+    _unimplemented(json, 'anyOf with ${anyOf.length} items');
   }
 
   return SchemaRef.schema(parseSchema(json));

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -448,11 +448,14 @@ Info parseInfo(MapContext json) {
 }
 
 OpenApi parseOpenApi(MapContext json) {
-  final minimumVersion = Version.parse('3.1.0');
+  final minimumVersion = Version.parse('3.0.0');
   final versionString = _required<String>(json, 'openapi');
   final version = Version.parse(versionString);
   if (version < minimumVersion) {
-    _warn(json, '$version may not be supported, only tested with 3.1.0');
+    _warn(
+      json,
+      '$version < $minimumVersion, the lowest known supported version.',
+    );
   }
 
   final info = parseInfo(_requiredMap(json, 'info'));

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -374,7 +374,7 @@ Components parseComponents(MapContext? json) {
     }
   }
 
-  final securitySchemesJson = json['securitySchemes'] as Json?;
+  final securitySchemesJson = _optionalMap(json, 'securitySchemes');
   if (securitySchemesJson != null) {
     logger.warn('Ignoring securitySchemes.');
   }
@@ -396,15 +396,14 @@ Components parseComponents(MapContext? json) {
     }
   }
 
-  final requestBodiesJson = json['requestBodies'] as Json?;
+  final requestBodiesJson = _optionalMap(json, 'requestBodies');
   final requestBodies = <String, RequestBody>{};
   if (requestBodiesJson != null) {
     for (final name in requestBodiesJson.keys) {
       final snakeName = snakeFromCamel(name);
-      final childContext = json
-          .addSnakeName(snakeName, isTopLevelComponent: true)
-          .childAsMap('requestBodies')
-          .childAsMap(name);
+      final childContext = requestBodiesJson
+          .childAsMap(name)
+          .addSnakeName(snakeName, isTopLevelComponent: true);
       requestBodies[name] = parseRequestBody(childContext);
     }
   }
@@ -556,7 +555,7 @@ class MapContext extends ParseContext {
          pointerParts: [...parent.pointerParts, key],
          snakeNameStack: parent.snakeNameStack,
          refRegistry: parent.refRegistry,
-         isTopLevelComponent: parent.isTopLevelComponent,
+         isTopLevelComponent: false,
          json: json,
        );
 
@@ -566,7 +565,7 @@ class MapContext extends ParseContext {
         pointerParts: [],
         snakeNameStack: [],
         refRegistry: RefRegistry(),
-        isTopLevelComponent: true,
+        isTopLevelComponent: false,
         json: json,
       );
 
@@ -634,7 +633,7 @@ class ListContext extends ParseContext {
          pointerParts: [...parent.pointerParts, key],
          snakeNameStack: parent.snakeNameStack,
          refRegistry: parent.refRegistry,
-         isTopLevelComponent: parent.isTopLevelComponent,
+         isTopLevelComponent: false,
          json: json,
        );
 

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -380,7 +380,10 @@ List<Response> parseResponses(MapContext responsesJson) {
   ];
 }
 
-Components parseComponents(MapContext json) {
+Components parseComponents(MapContext? json) {
+  if (json == null) {
+    return const Components();
+  }
   final keys = json.keys.toList();
   final supportedKeys = ['schemas', 'securitySchemes', 'requestBodies'];
 
@@ -474,10 +477,7 @@ OpenApi parseOpenApi(MapContext json) {
       );
     }
   }
-  final componentsJson = _optionalMap(json, 'components');
-  final components = componentsJson == null
-      ? const Components(schemas: {}, requestBodies: {})
-      : parseComponents(componentsJson);
+  final components = parseComponents(_optionalMap(json, 'components'));
   return OpenApi(
     serverUrl: Uri.parse(serverUrl),
     version: version,

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -100,10 +100,7 @@ Parameter parseParameter(MapContext json) {
   _ignored(json, 'allowEmptyValue');
 
   final SchemaRef type;
-  if (hasSchema) {
-    if (hasContent) {
-      _error(json, 'Parameter cannot have both schema and content');
-    }
+  if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
     _ignored(json, 'style');
@@ -111,12 +108,13 @@ Parameter parseParameter(MapContext json) {
     _ignored(json, 'allowReserved');
     _ignored(json, 'example');
     _ignored(json, 'examples');
+  } else if (!hasSchema && hasContent) {
+    // Content values (Map<String, MediaType>) are not supported.
+    _unimplemented(json, "'content'");
+  } else if (hasSchema && hasContent) {
+    _error(json, 'Parameter cannot have both schema and content');
   } else {
-    if (!hasSchema && !hasContent) {
-      _error(json, 'Parameter must have either schema or content');
-    }
-    // Content fields.
-    _unimplemented(json, 'Content parameters');
+    _error(json, 'Parameter must have either schema or content, not both');
   }
 
   if (sendIn == SendIn.cookie) {

--- a/packages/gen/lib/src/render.dart
+++ b/packages/gen/lib/src/render.dart
@@ -36,10 +36,10 @@ Future<void> loadAndRenderSpec({
 
   // Load the spec and warm the cache before rendering.
   final cache = Cache(fs);
-  final parseContext = ParseContext.initial(specUri);
   final specJson = await cache.load(specUri);
-  final spec = parseOpenApi(specJson, parseContext);
-  _printSpecStats(parseContext, spec);
+  final context = MapContext.initial(specUri, specJson);
+  final spec = parseOpenApi(context);
+  _printSpecStats(context, spec);
 
   // Pre-warm the cache. Rendering assumes all refs are present in the cache.
   for (final ref in collectRefs(spec)) {
@@ -58,7 +58,7 @@ Future<void> loadAndRenderSpec({
 
   renderSpec(
     spec: spec,
-    refRegistry: parseContext.refRegistry,
+    refRegistry: context.refRegistry,
     specUri: specUri,
     outDir: outDir,
     packageName: packageName,

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -354,9 +354,7 @@ class Response extends Equatable {
 
 @immutable
 class Components extends Equatable {
-  const Components({required this.schemas, required this.requestBodies});
-
-  const Components.empty() : schemas = const {}, requestBodies = const {};
+  const Components({this.schemas = const {}, this.requestBodies = const {}});
 
   final Map<String, Schema> schemas;
   // final Map<String, Parameter> parameters;

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -356,6 +356,8 @@ class Response extends Equatable {
 class Components extends Equatable {
   const Components({required this.schemas, required this.requestBodies});
 
+  const Components.empty() : schemas = const {}, requestBodies = const {};
+
   final Map<String, Schema> schemas;
   // final Map<String, Parameter> parameters;
   // final Map<String, SecurityScheme> securitySchemes;

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -609,6 +609,28 @@ void main() {
         ),
       );
     });
+
+    test('responses without content are ignored', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final spec = parseTestSpec(json);
+      // This is not correct, but documents our current behavior.
+      expect(spec.endpoints.first.responses, isEmpty);
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -10,8 +10,7 @@ void main() {
   group('OpenApi', () {
     OpenApi parseTestSpec(Map<String, dynamic> json) {
       return parseOpenApi(
-        json,
-        ParseContext.initial(Uri.parse('file:///foo.json')),
+        MapContext.initial(Uri.parse('file:///foo.json'), json),
       );
     }
 

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -58,7 +58,20 @@ void main() {
           'enum': [1, 2, 3],
         },
       };
-      expect(() => parseTestSchemas(json), throwsA(isA<UnimplementedError>()));
+      expect(
+        () => parseTestSchemas(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'enumValues for type=SchemaType.number not supported in '
+              'MapContext(/components/schemas/NumberEnum, '
+              '{type: number, enum: [1, 2, 3]})',
+            ),
+          ),
+        ),
+      );
     });
 
     test('equals', () {
@@ -166,7 +179,44 @@ void main() {
           ],
         },
       };
-      expect(() => parseTestSchemas(json), throwsA(isA<UnimplementedError>()));
+      expect(
+        () => parseTestSchemas(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'anyOf with 2 items not supported in '
+              'MapContext(/components/schemas/User, '
+              '{anyOf: [{type: boolean}, {type: string}]})',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('oneOf not supported', () {
+      final json = {
+        'User': {
+          'oneOf': [
+            {'type': 'boolean'},
+          ],
+        },
+      };
+      expect(
+        () => parseTestSchemas(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'oneOf not supported in '
+              'MapContext(/components/schemas/User, '
+              '{oneOf: [{type: boolean}]})',
+            ),
+          ),
+        ),
+      );
     });
 
     test('components schemas as ref not supported', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -260,9 +260,9 @@ void main() {
         ),
       );
     });
-    test('warn on version below 3.1.0', () {
+    test('warn on version below 3.0.0', () {
       final json = {
-        'openapi': '3.0.0',
+        'openapi': '2.9.9',
         'info': {'title': 'Space Traders API', 'version': '1.0.0.a.b.c'},
         'servers': [
           {'url': 'https://api.spacetraders.io/v2'},
@@ -278,10 +278,10 @@ void main() {
       final spec = runWithLogger(logger, () => parseTestSpec(json));
       verify(
         () => logger.warn(
-          '3.0.0 may not be supported, only tested with 3.1.0 in /',
+          '2.9.9 < 3.0.0, the lowest known supported version. in /',
         ),
       ).called(1);
-      expect(spec.version, Version.parse('3.0.0'));
+      expect(spec.version, Version.parse('2.9.9'));
       // Info.version is the version of the spec, not the version of the OpenAPI
       // schema used to generate it and can be an arbitrary string.
       expect(spec.info.version, '1.0.0.a.b.c');

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -415,6 +415,79 @@ void main() {
         ),
       );
     });
+
+    test('path parameters must be strings', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'summary': 'Get user',
+              'parameters': [
+                {
+                  'name': 'foo',
+                  'in': 'path',
+                  'schema': {'type': 'number'},
+                },
+              ],
+            },
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'Path parameters must be strings in /paths//users/get/parameters/0',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('path parameters must be required', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'summary': 'Get user',
+              'parameters': [
+                {
+                  'name': 'foo',
+                  'in': 'path',
+                  'schema': {'type': 'string'},
+                  // required is missing and defaults to false.
+                },
+              ],
+            },
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'Path parameters must be required in /paths//users/get/parameters/0',
+            ),
+          ),
+        ),
+      );
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -575,6 +575,40 @@ void main() {
         ),
       );
     });
+
+    test('multiple responses not supported', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+                '201': {'description': 'Created'},
+              },
+            },
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'Multiple responses not supported in '
+              'MapContext(/paths//users/get/responses, '
+              '{200: {description: OK}, 201: {description: Created}})',
+            ),
+          ),
+        ),
+      );
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -309,7 +309,7 @@ void main() {
             (e) => e.message,
             'message',
             equals(
-              'Key responses is not of type Map<String, dynamic>: true (in /paths//users/get)',
+              "'responses' is not of type Map<String, dynamic>: true in /paths//users/get",
             ),
           ),
         ),
@@ -332,6 +332,25 @@ void main() {
             (e) => e.message,
             'message',
             equals('Path cannot be empty in /paths/'),
+          ),
+        ),
+      );
+    });
+
+    test('info is required', () {
+      final json = {
+        'openapi': '3.1.0',
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals('Key info is required in /'),
           ),
         ),
       );

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -689,6 +689,42 @@ void main() {
         ),
       );
     });
+
+    test('ListContext.indexAsMap throws on missing child', () {
+      final context = ListContext(
+        baseUrl: Uri.parse('file:///foo.json'),
+        pointerParts: const ['root'],
+        snakeNameStack: const [],
+        refRegistry: RefRegistry(),
+        isTopLevelComponent: false,
+        json: [
+          {'foo': 'bar'},
+          'baz',
+        ],
+      );
+      expect(context.pointer, const JsonPointer(['root']));
+      expect(context.indexAsMap(0), isA<MapContext>());
+      expect(
+        () => context.indexAsMap(1),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals('Index 1 is not of type Map<String, dynamic>: baz in /root'),
+          ),
+        ),
+      );
+      expect(
+        () => context.indexAsMap(2),
+        throwsA(
+          isA<RangeError>().having(
+            (e) => e.message,
+            'message',
+            equals('Invalid value'),
+          ),
+        ),
+      );
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -661,6 +661,34 @@ void main() {
         ),
       );
     });
+
+    test('MapContext.childAsList throws on missing child', () {
+      final context = MapContext.initial(Uri.parse('file:///foo.json'), {
+        'foo': ['bar'],
+      });
+      expect(context.pointer, const JsonPointer([]));
+      expect(context.childAsList('foo'), isA<ListContext>());
+      expect(
+        () => context.childAsMap('foo'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals("'foo' is not of type Map<String, dynamic>: [bar] in /"),
+          ),
+        ),
+      );
+      expect(
+        () => context.childAsMap('bar'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            equals('Key not found: bar in /'),
+          ),
+        ),
+      );
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -260,6 +260,50 @@ void main() {
         ),
       );
     });
+
+    test('content is not supported', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'summary': 'Get user',
+              'parameters': [
+                {
+                  'name': 'foo',
+                  'in': 'query',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'boolean'},
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              "'content' not supported in "
+              'MapContext(/paths//users/get/parameters/0, {name: foo, '
+              'in: query, content: {application/json: '
+              '{schema: {type: boolean}}}})',
+            ),
+          ),
+        ),
+      );
+    });
+
     test('warn on version below 3.0.0', () {
       final json = {
         'openapi': '2.9.9',

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -355,6 +355,22 @@ void main() {
         ),
       );
     });
+    test('servers is required', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals('Key servers is required in /'),
+          ),
+        ),
+      );
+    });
   });
 
   group('JsonPointer', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -195,6 +195,43 @@ void main() {
       );
     });
 
+    test('allOf with one item', () {
+      final json = {
+        'User': {
+          'allOf': [
+            {'type': 'boolean'},
+          ],
+        },
+      };
+      final schemas = parseTestSchemas(json);
+      expect(schemas['User']!.type, SchemaType.boolean);
+    });
+
+    test('allOf with multiple items', () {
+      final json = {
+        'User': {
+          'allOf': [
+            {'type': 'boolean'},
+            {'type': 'string'},
+          ],
+        },
+      };
+      expect(
+        () => parseTestSchemas(json),
+        throwsA(
+          isA<UnimplementedError>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'allOf with 2 items not supported in '
+              'MapContext(/components/schemas/User, '
+              '{allOf: [{type: boolean}, {type: string}]})',
+            ),
+          ),
+        ),
+      );
+    });
+
     test('oneOf not supported', () {
       final json = {
         'User': {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -633,6 +633,36 @@ void main() {
     });
   });
 
+  group('ParseContext', () {
+    test('MapContext.childAsMap throws on missing child', () {
+      final context = MapContext.initial(Uri.parse('file:///foo.json'), {
+        'foo': {'bar': 'baz'},
+      });
+      expect(context.pointer, const JsonPointer([]));
+      expect(context.childAsMap('foo'), isA<MapContext>());
+      expect(
+        () => context.childAsList('foo'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals("'foo' is not of type List<dynamic>: {bar: baz} in /"),
+          ),
+        ),
+      );
+      expect(
+        () => context.childAsMap('bar'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            equals('Key not found: bar in /'),
+          ),
+        ),
+      );
+    });
+  });
+
   group('JsonPointer', () {
     test('equality', () {
       const pointerOne = JsonPointer(['foo', 'bar']);


### PR DESCRIPTION
This isn't perfect, but feels like the right direction to move JsonPointer into the "json" variable, even if we might later split out the SnakeName, refRegistry, and isTopLevelComponent stuff again. 