### PR TITLE
fix: make responses required, per spec

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -73,3 +73,4 @@ words:
   - MICROABRASIONS
   - FEBA
   - newtype
+  - contentful

--- a/packages/gen/lib/src/context.dart
+++ b/packages/gen/lib/src/context.dart
@@ -65,12 +65,8 @@ extension _EndpointGeneration on Endpoint {
   /// The type of the response.
   /// If there are multiple responses, we return the first one with a content
   /// type.
-  SchemaRef? get responseTypeRef {
-    if (responses.isEmpty) {
-      return null;
-    }
-    return responses.contentfulResponses.firstOrNull?.content;
-  }
+  SchemaRef? get responseTypeRef =>
+      responses.contentfulResponses.firstOrNull?.content;
 
   Map<String, dynamic> toTemplateContext(_Context context) {
     final serverParameters = parameters

--- a/packages/gen/lib/src/context.dart
+++ b/packages/gen/lib/src/context.dart
@@ -62,6 +62,16 @@ extension _EndpointGeneration on Endpoint {
 
   Uri uri(_Context context) => Uri.parse('${context.spec.serverUrl}$path');
 
+  /// The type of the response.
+  /// If there are multiple responses, we return the first one with a content
+  /// type.
+  SchemaRef? get responseTypeRef {
+    if (responses.isEmpty) {
+      return null;
+    }
+    return responses.values.firstWhereOrNull(Response.hasContent)?.content;
+  }
+
   Map<String, dynamic> toTemplateContext(_Context context) {
     final serverParameters = parameters
         .map((param) => param.toTemplateContext(context))
@@ -73,8 +83,8 @@ extension _EndpointGeneration on Endpoint {
     // body if it exists.
     final dartParameters = [...serverParameters, ?requestBody];
 
-    final firstResponse = context._maybeResolve(responses.firstOrNull?.content);
-    final returnType = firstResponse?.typeName(context) ?? 'void';
+    final returnType =
+        context._maybeResolve(responseTypeRef)?.typeName(context) ?? 'void';
 
     final namedParameters = dartParameters.where((p) => p['required'] == false);
     final positionalParameters = dartParameters.where(
@@ -998,7 +1008,8 @@ class _RenderContext {
   // TODO(eseidel): Could use Visitor for this?
   void collectApi(Api api) {
     for (final endpoint in api.endpoints) {
-      for (final response in endpoint.responses) {
+      visitRef(endpoint.responseTypeRef);
+      for (final response in endpoint.responses.values) {
         visitRef(response.content);
       }
       for (final param in endpoint.parameters) {

--- a/packages/gen/lib/src/context.dart
+++ b/packages/gen/lib/src/context.dart
@@ -69,7 +69,7 @@ extension _EndpointGeneration on Endpoint {
     if (responses.isEmpty) {
       return null;
     }
-    return responses.values.firstWhereOrNull(Response.hasContent)?.content;
+    return responses.contentfulResponses.firstOrNull?.content;
   }
 
   Map<String, dynamic> toTemplateContext(_Context context) {
@@ -1009,7 +1009,7 @@ class _RenderContext {
   void collectApi(Api api) {
     for (final endpoint in api.endpoints) {
       visitRef(endpoint.responseTypeRef);
-      for (final response in endpoint.responses.values) {
+      for (final response in endpoint.responses.contentfulResponses) {
         visitRef(response.content);
       }
       for (final param in endpoint.parameters) {

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -131,8 +131,9 @@ Parameter parseParameter(MapContext json) {
     _unimplemented(json, 'in=cookie');
   }
   if (sendIn == SendIn.path) {
-    if (type.schema?.type != SchemaType.string) {
-      _error(json, 'Path parameters must be strings');
+    final schemaType = type.schema?.type;
+    if (schemaType != SchemaType.string && schemaType != SchemaType.integer) {
+      _error(json, 'Path parameters must be strings or integers');
     }
     if (required != true) {
       _error(json, 'Path parameters must be required');

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -316,8 +316,10 @@ Endpoint parseEndpoint({
         Uri.parse(path).pathSegments.last,
   );
   final context = endpointJson.addSnakeName(snakeName);
-  final responses = parseResponses(_optionalMap(context, 'responses'));
-  if (responses.values.where(Response.hasContent).length > 1) {
+  // Operation does not mention 'responses' as being required, but
+  // the Responses object says at least one response is required.
+  final responses = parseResponses(_requiredMap(context, 'responses'));
+  if (responses.contentfulResponses.length > 1) {
     _unimplemented(context, 'Multiple responses with content');
   }
   if (responses.isEmpty) {
@@ -357,10 +359,7 @@ Response _parseResponse(MapContext responseJson) {
   return Response(description: description, content: parseSchemaOrRef(schema));
 }
 
-Map<int, Response> parseResponses(MapContext? responsesJson) {
-  if (responsesJson == null) {
-    return {};
-  }
+Responses parseResponses(MapContext responsesJson) {
   final responseCodes = responsesJson.keys.toList();
 
   // We don't yet support default responses.
@@ -378,7 +377,7 @@ Map<int, Response> parseResponses(MapContext? responsesJson) {
     }
     responses[responseCodeInt] = _parseResponse(responseJson);
   }
-  return responses;
+  return Responses(responses: responses);
 }
 
 Map<String, T> _parseComponent<T>(

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -57,13 +57,20 @@ MapContext? _optionalMap(MapContext parent, String key) {
   return parent.childAsMap(key);
 }
 
-ListContext? _optionalList(MapContext parent, String key) {
+Iterable<T> _mapOptionalList<T>(
+  MapContext parent,
+  String key,
+  T Function(MapContext, int) parse,
+) sync* {
   final value = parent[key];
   if (value == null) {
-    return null;
+    return;
   }
-  _expectType<List<dynamic>>(parent, key, value);
-  return parent.childAsList(key);
+
+  final list = parent.childAsList(key);
+  for (var i = 0; i < list.length; i++) {
+    yield parse(list.indexAsMap(i), i);
+  }
 }
 
 Never _unimplemented(ParseContext json, String message) {
@@ -117,7 +124,7 @@ Parameter parseParameter(MapContext json) {
   } else if (hasSchema && hasContent) {
     _error(json, 'Parameter cannot have both schema and content');
   } else {
-    _error(json, 'Parameter must have either schema or content, not both');
+    _error(json, 'Parameter must have either schema or content.');
   }
 
   if (sendIn == SendIn.cookie) {
@@ -270,7 +277,10 @@ SchemaRef parseSchemaOrRef(MapContext json) {
 /// Parse a schema or a reference to a schema.
 /// https://spec.openapis.org/oas/v3.0.0#schemaObject
 /// https://spec.openapis.org/oas/v3.0.0#relative-references-in-urls
-RefOr<RequestBody> parseRequestBodyOrRef(MapContext json) {
+RefOr<RequestBody>? parseRequestBodyOrRef(MapContext? json) {
+  if (json == null) {
+    return null;
+  }
   if (json.containsKey(r'$ref')) {
     return RefOr<RequestBody>.ref(json[r'$ref'] as String);
   }
@@ -300,35 +310,28 @@ Endpoint parseEndpoint({
   required String path,
   required Method method,
 }) {
-  final operationId = _optional<String>(endpointJson, 'operationId');
-  final snakeName = (operationId ?? Uri.parse(path).pathSegments.last)
-      .replaceAll('-', '_');
-
+  final snakeName = snakeFromKebab(
+    _optional<String>(endpointJson, 'operationId') ??
+        Uri.parse(path).pathSegments.last,
+  );
   final context = endpointJson.addSnakeName(snakeName);
-  final responsesJson = _optionalMap(context, 'responses');
-  final responses = responsesJson == null
-      ? <Response>[]
-      : parseResponses(responsesJson);
+  final responses = parseResponses(_optionalMap(context, 'responses'));
+  if (responses.values.where(Response.hasContent).length > 1) {
+    _unimplemented(context, 'Multiple responses with content');
+  }
+  if (responses.isEmpty) {
+    _error(context, 'Responses are required');
+  }
   final tags = _optional<List<dynamic>>(context, 'tags');
   final tag = tags?.firstOrNull as String? ?? 'Default';
-  final parametersJson = _optionalList(context, 'parameters');
-  final parameters = parametersJson == null
-      ? <Parameter>[]
-      : parametersJson.indexed
-            .map(
-              (indexed) => parseParameter(
-                context
-                    .childAsList('parameters')
-                    .indexAsMap(indexed.$1)
-                    .addSnakeName('parameter${indexed.$1}'),
-              ),
-            )
-            .toList();
-  final requestBodyJson = _optionalMap(context, 'requestBody');
-  RefOr<RequestBody>? requestBody;
-  if (requestBodyJson != null) {
-    requestBody = parseRequestBodyOrRef(requestBodyJson);
-  }
+  final parameters = _mapOptionalList(
+    context,
+    'parameters',
+    (child, index) => parseParameter(child.addSnakeName('parameter$index')),
+  ).toList();
+  final requestBody = parseRequestBodyOrRef(
+    _optionalMap(context, 'requestBody'),
+  );
   return Endpoint(
     path: path,
     method: method,
@@ -340,25 +343,41 @@ Endpoint parseEndpoint({
   );
 }
 
-List<Response> parseResponses(MapContext responsesJson) {
-  final responseCodes = responsesJson.keys.toList()..remove('204');
-  if (responseCodes.length != 1) {
-    _unimplemented(responsesJson, 'Multiple responses');
-  }
-
-  final responseCode = responseCodes.first;
-  final forCode = responsesJson
-      .childAsMap(responseCode)
-      .addSnakeName(responseCode);
-  final content = _optionalMap(forCode, 'content');
+Response _parseResponse(MapContext responseJson) {
+  final description = _required<String>(responseJson, 'description');
+  _ignored<dynamic>(responseJson, 'headers');
+  _ignored<dynamic>(responseJson, 'links');
+  final content = _optionalMap(responseJson, 'content');
   if (content == null) {
-    return [];
+    return Response(description: description);
   }
   final jsonResponse = _requiredMap(content, 'application/json');
   final schema = jsonResponse.childAsMap('schema').addSnakeName('response');
-  return [
-    Response(code: int.parse(responseCode), content: parseSchemaOrRef(schema)),
-  ];
+  return Response(description: description, content: parseSchemaOrRef(schema));
+}
+
+Map<int, Response> parseResponses(MapContext? responsesJson) {
+  if (responsesJson == null) {
+    return {};
+  }
+  final responseCodes = responsesJson.keys.toList();
+
+  // We don't yet support default responses.
+  _ignored<Map<String, dynamic>>(responsesJson, 'default');
+  responseCodes.remove('default');
+
+  final responses = <int, Response>{};
+  for (final responseCode in responseCodes) {
+    final responseJson = responsesJson
+        .childAsMap(responseCode)
+        .addSnakeName(responseCode);
+    final responseCodeInt = int.tryParse(responseCode);
+    if (responseCodeInt == null) {
+      _error(responsesJson, 'Invalid response code: $responseCode');
+    }
+    responses[responseCodeInt] = _parseResponse(responseJson);
+  }
+  return responses;
 }
 
 Map<String, T> _parseComponent<T>(
@@ -662,8 +681,6 @@ class ListContext extends ParseContext {
   }
 
   int get length => json.length;
-
-  Iterable<(int, dynamic)> get indexed => json.indexed;
 
   final List<dynamic> json;
 }

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -310,7 +310,7 @@ class Endpoint extends Equatable {
   final String tag;
 
   /// The responses of this endpoint.
-  final List<Response> responses;
+  final Map<int, Response> responses;
 
   /// The snake name of this endpoint (e.g. get_user)
   /// Typically the operationId, or the last path segment if not present.
@@ -339,17 +339,33 @@ class Endpoint extends Equatable {
 @immutable
 class Response extends Equatable {
   /// Create a new response.
-  const Response({required this.code, required this.content});
+  const Response({required this.description, this.content});
 
-  /// The status code of this response.
-  final int code;
+  /// The description of this response.
+  final String description;
 
   /// The content of this response.
   /// The official spec has a map here by mime type, but we only support json.
-  final SchemaRef content;
+  final SchemaRef? content;
+
+  /// Whether this response has content.
+  /// We only support json, so we check for a schema with a type.
+  /// This is a bit of a hack for the space traders spec which has a 204
+  /// response with an empty schema.
+  static bool hasContent(Response response) {
+    final content = response.content;
+    if (content == null) {
+      return false;
+    }
+    final schema = content.schema;
+    if (schema == null) {
+      return false;
+    }
+    return schema.type != SchemaType.unknown;
+  }
 
   @override
-  List<Object?> get props => [code, content];
+  List<Object?> get props => [description, content];
 }
 
 @immutable

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -310,7 +310,7 @@ class Endpoint extends Equatable {
   final String tag;
 
   /// The responses of this endpoint.
-  final Map<int, Response> responses;
+  final Responses responses;
 
   /// The snake name of this endpoint (e.g. get_user)
   /// Typically the operationId, or the last path segment if not present.
@@ -332,6 +332,34 @@ class Endpoint extends Equatable {
     parameters,
     requestBody,
   ];
+}
+
+/// A map of response codes to responses.
+/// https://spec.openapis.org/oas/v3.1.0#responses-object
+@immutable
+class Responses extends Equatable {
+  /// Create a new responses object.
+  const Responses({required this.responses});
+
+  /// The responses of this endpoint.
+  final Map<int, Response> responses;
+
+  // default is not yet supported.
+
+  /// The contentful responses of this endpoint.
+  List<Response> get contentfulResponses =>
+      responses.values.where(Response.hasContent).toList();
+
+  /// Whether this endpoint has any content-ful responses.
+  bool get hasContentfulResponses => contentfulResponses.isNotEmpty;
+
+  /// Whether this endpoint has any responses.
+  bool get isEmpty => responses.isEmpty;
+
+  Response? operator [](int code) => responses[code];
+
+  @override
+  List<Object?> get props => [responses];
 }
 
 /// A response from an endpoint.

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -350,9 +350,6 @@ class Responses extends Equatable {
   List<Response> get contentfulResponses =>
       responses.values.where(Response.hasContent).toList();
 
-  /// Whether this endpoint has any content-ful responses.
-  bool get hasContentfulResponses => contentfulResponses.isNotEmpty;
-
   /// Whether this endpoint has any responses.
   bool get isEmpty => responses.isEmpty;
 

--- a/packages/gen/lib/src/string.dart
+++ b/packages/gen/lib/src/string.dart
@@ -8,6 +8,7 @@ String snakeFromCamel(String camel) {
   return snake.startsWith('_') ? snake.substring(1) : snake;
 }
 
+/// Convert snake_case to CamelCase.
 String camelFromSnake(String snake) {
   return snake.splitMapJoin(
     RegExp('_'),
@@ -16,7 +17,10 @@ String camelFromSnake(String snake) {
   );
 }
 
-// Converts from SCREAMING_CAPS to camelCase.
+/// Convert kebab-case to snake_case.
+String snakeFromKebab(String kebab) => kebab.replaceAll('-', '_');
+
+/// Converts from SCREAMING_CAPS to camelCase.
 String camelFromScreamingCaps(String caps) {
   final camel = caps.splitMapJoin(
     RegExp('_'),

--- a/packages/gen/lib/src/visitor.dart
+++ b/packages/gen/lib/src/visitor.dart
@@ -48,7 +48,7 @@ class SpecWalker {
     for (final parameter in endpoint.parameters) {
       _parameter(parameter);
     }
-    for (final response in endpoint.responses) {
+    for (final response in endpoint.responses.values) {
       _maybeRef(response.content);
     }
     _maybeRef(endpoint.requestBody);

--- a/packages/gen/lib/src/visitor.dart
+++ b/packages/gen/lib/src/visitor.dart
@@ -48,7 +48,7 @@ class SpecWalker {
     for (final parameter in endpoint.parameters) {
       _parameter(parameter);
     }
-    for (final response in endpoint.responses.values) {
+    for (final response in endpoint.responses.contentfulResponses) {
       _maybeRef(response.content);
     }
     _maybeRef(endpoint.requestBody);

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -571,7 +571,8 @@ void main() {
             (e) => e.message,
             'message',
             equals(
-              'Path parameters must be strings in /paths//users/get/parameters/0',
+              'Path parameters must be strings or integers in '
+              '/paths//users/get/parameters/0',
             ),
           ),
         ),

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -701,6 +701,38 @@ void main() {
       expect(spec.endpoints.first.responses[200]!.content, isNotNull);
       expect(spec.endpoints.first.responses[204]!.content, isNotNull);
     });
+
+    test('only integers and default are supported as response codes', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+                'barf': {'description': 'Barf'},
+              },
+            },
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals(
+              'Invalid response code: barf in /paths//users/get/responses',
+            ),
+          ),
+        ),
+      );
+    });
   });
 
   group('ParseContext', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -733,6 +733,33 @@ void main() {
         ),
       );
     });
+    test('default response is not supported', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                'default': {'description': 'Default'},
+                '201': {'description': 'Created'},
+              },
+            },
+          },
+        },
+      };
+      final logger = _MockLogger();
+      final spec = runWithLogger(logger, () => parseTestSpec(json));
+      verify(
+        () => logger.detail(
+          'Ignoring key: default in /paths//users/get/responses',
+        ),
+      ).called(1);
+      expect(spec.endpoints.first.responses[200], isNull);
+    });
   });
 
   group('ParseContext', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -760,6 +760,31 @@ void main() {
       ).called(1);
       expect(spec.endpoints.first.responses[200], isNull);
     });
+
+    test('responses are required', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {'responses': <String, dynamic>{}},
+          },
+        },
+      };
+      expect(
+        () => parseTestSpec(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            equals('Responses are required in /paths//users/get'),
+          ),
+        ),
+      );
+    });
   });
 
   group('ParseContext', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -23,7 +23,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
         'components': {'schemas': schemasJson},
@@ -41,7 +46,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
       };
@@ -83,16 +93,23 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
-            'parameters': [
-              {'name': 'foo', 'in': 'query', 'required': true},
-            ],
-            'responses': {
-              '200': {
-                'description': 'OK',
-                'content': {
-                  'application/json': {
-                    'schema': {'type': 'object'},
+            'get': {
+              'summary': 'Get user',
+              'parameters': [
+                {
+                  'name': 'foo',
+                  'in': 'query',
+                  'required': true,
+                  'schema': {'type': 'string'},
+                },
+              ],
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'object'},
+                    },
                   },
                 },
               },
@@ -113,7 +130,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
       };
@@ -303,6 +325,9 @@ void main() {
                   },
                 },
               ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
             },
           },
         },
@@ -332,6 +357,9 @@ void main() {
               'parameters': [
                 {'name': 'foo', 'in': 'query'},
               ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
             },
           },
         },
@@ -370,6 +398,9 @@ void main() {
                   },
                 },
               ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
             },
           },
         },
@@ -400,7 +431,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
       };
@@ -521,6 +557,9 @@ void main() {
                   'schema': {'type': 'number'},
                 },
               ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
             },
           },
         },
@@ -558,6 +597,9 @@ void main() {
                   // required is missing and defaults to false.
                 },
               ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
             },
           },
         },
@@ -576,7 +618,7 @@ void main() {
       );
     });
 
-    test('multiple responses not supported', () {
+    test('multiple responses with content not supported', () {
       final json = {
         'openapi': '3.1.0',
         'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -587,8 +629,22 @@ void main() {
           '/users': {
             'get': {
               'responses': {
-                '200': {'description': 'OK'},
-                '201': {'description': 'Created'},
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'boolean'},
+                    },
+                  },
+                },
+                '201': {
+                  'description': 'Created',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'string'},
+                    },
+                  },
+                },
               },
             },
           },
@@ -600,17 +656,13 @@ void main() {
           isA<UnimplementedError>().having(
             (e) => e.message,
             'message',
-            equals(
-              'Multiple responses not supported in '
-              'MapContext(/paths//users/get/responses, '
-              '{200: {description: OK}, 201: {description: Created}})',
-            ),
+            contains('Multiple responses with content not supported'),
           ),
         ),
       );
     });
 
-    test('responses without content are ignored', () {
+    test('multiple responses with content ignores empty responses', () {
       final json = {
         'openapi': '3.1.0',
         'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -621,15 +673,32 @@ void main() {
           '/users': {
             'get': {
               'responses': {
-                '200': {'description': 'OK'},
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {'type': 'boolean'},
+                    },
+                  },
+                },
+                '204': {
+                  'description': 'No content',
+                  'content': {
+                    'application/json': {
+                      // This doesn't error because schema is empty.
+                      // This is a hack for Space Traders get-cooldown.
+                      'schema': {'description': 'No content'},
+                    },
+                  },
+                },
               },
             },
           },
         },
       };
       final spec = parseTestSpec(json);
-      // This is not correct, but documents our current behavior.
-      expect(spec.endpoints.first.responses, isEmpty);
+      expect(spec.endpoints.first.responses[200]!.content, isNotNull);
+      expect(spec.endpoints.first.responses[204]!.content, isNotNull);
     });
   });
 

--- a/packages/gen/test/render_test.dart
+++ b/packages/gen/test/render_test.dart
@@ -99,7 +99,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
       };
@@ -130,7 +135,12 @@ void main() {
         ],
         'paths': {
           '/users': {
-            'get': {'summary': 'Get user'},
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
           },
         },
       };
@@ -556,6 +566,9 @@ void main() {
               'requestBody': {
                 r'$ref': '#/components/requestBodies/PurchaseCargoRequest',
               },
+              'responses': {
+                '201': {'description': 'Purchased goods successfully.'},
+              },
             },
           },
         },
@@ -686,30 +699,32 @@ void main() {
         ],
         'paths': {
           '/my/ships': {
-            'get': {'operationId': 'get-my-ships'},
-            'responses': {
-              '200': {
-                'description': 'Default Response',
-                'content': {
-                  'application/json': {
-                    'schema': {
-                      'type': 'object',
-                      'properties': {
-                        'foo': {
-                          'type': 'array',
-                          'items': {'type': 'string'},
-                        },
-                        'bar': {
-                          'type': 'array',
-                          'items': {'type': 'number'},
-                        },
-                        'baz': {
-                          'type': 'array',
-                          'items': {'type': 'integer'},
-                        },
-                        'qux': {
-                          'type': 'array',
-                          'items': {'type': 'boolean'},
+            'get': {
+              'operationId': 'get-my-ships',
+              'responses': {
+                '200': {
+                  'description': 'Default Response',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'type': 'object',
+                        'properties': {
+                          'foo': {
+                            'type': 'array',
+                            'items': {'type': 'string'},
+                          },
+                          'bar': {
+                            'type': 'array',
+                            'items': {'type': 'number'},
+                          },
+                          'baz': {
+                            'type': 'array',
+                            'items': {'type': 'integer'},
+                          },
+                          'qux': {
+                            'type': 'array',
+                            'items': {'type': 'boolean'},
+                          },
                         },
                       },
                     },
@@ -724,7 +739,10 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(out.childFile('lib/api/default_api.dart'), exists);
-      expect(out.childDirectory('lib/model'), isNot(exists));
+      expect(
+        out.childDirectory('lib/model'),
+        hasFiles(['get_my_ships200_response.dart']),
+      );
     });
 
     test('in=cookie and in=header not supported', () async {
@@ -746,6 +764,9 @@ void main() {
                     'in': sendIn,
                   },
                 ],
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
               },
             },
           },
@@ -761,6 +782,31 @@ void main() {
         renderToDirectory(spec: withIn('header')),
         throwsA(isA<UnimplementedError>()),
       );
+    });
+
+    test('responses without content are ignored', () async {
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final fs = MemoryFileSystem.test();
+      final out = fs.directory('spacetraders');
+
+      await renderToDirectory(spec: spec, outDir: out);
+      expect(out.childFile('lib/api/default_api.dart'), exists);
+      expect(out.childDirectory('lib/model'), isNot(exists));
     });
   });
 }


### PR DESCRIPTION
I also removed the hack for 204 by making it OK to have multiple
responses with empty schemas.