### PR TITLE
feat: parse anyOf, oneOf, allOf (even if not rendered yet)

### DIFF
--- a/packages/gen/README.md
+++ b/packages/gen/README.md
@@ -31,6 +31,7 @@ dart run space_gen
 * Simplify hasAdditionalProperties.
 * Remove anyOf hack for RefuelShipRequest.fromCargo.
 * Fix toString hack for queryParameters.
+* Move to a sealed class for Schema that allows for AnyOf, AllOf, OneOf variants?
 
 Is the body sometimes passed in as an object, and sometimes created by
 the endpoint?  Or is it always created by the endpoint?

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -147,7 +147,13 @@ Parameter parseParameter(MapContext json) {
   }
 
   if (sendIn == SendIn.path) {
-    final schemaType = type.schema?.type;
+    final schema = type.schema;
+    final SchemaType schemaType;
+    if (schema is Schema) {
+      schemaType = schema.type;
+    } else {
+      _error(json, 'Path parameters must be strings or integers');
+    }
     if (schemaType != SchemaType.string && schemaType != SchemaType.integer) {
       _error(json, 'Path parameters must be strings or integers');
     }
@@ -251,16 +257,36 @@ SchemaRef parseSchemaOrRef(MapContext json) {
   }
 
   if (json.containsKey('oneOf')) {
-    // TODO(eseidel): Support oneOf
-    _unimplemented(json, 'oneOf');
+    final oneOf = json.childAsList('oneOf');
+    final schemas = <SchemaRef>[];
+    for (var i = 0; i < oneOf.length; i++) {
+      schemas.add(parseSchemaOrRef(oneOf.indexAsMap(i)));
+    }
+    return SchemaRef.schema(
+      SchemaOneOf(
+        pointer: json.pointer.toString(),
+        snakeName: json.snakeName,
+        schemas: schemas,
+      ),
+    );
   }
 
   if (json.containsKey('allOf')) {
     final allOf = json.childAsList('allOf');
-    if (allOf.length != 1) {
-      _unimplemented(json, 'allOf with ${allOf.length} items');
+    if (allOf.length == 1) {
+      return parseSchemaOrRef(allOf.indexAsMap(0));
     }
-    return parseSchemaOrRef(allOf.indexAsMap(0));
+    final schemas = <SchemaRef>[];
+    for (var i = 0; i < allOf.length; i++) {
+      schemas.add(parseSchemaOrRef(allOf.indexAsMap(i)));
+    }
+    return SchemaRef.schema(
+      SchemaAllOf(
+        pointer: json.pointer.toString(),
+        snakeName: json.snakeName,
+        schemas: schemas,
+      ),
+    );
   }
 
   if (json.containsKey('anyOf')) {
@@ -294,7 +320,17 @@ SchemaRef parseSchemaOrRef(MapContext json) {
       }
     }
 
-    _unimplemented(json, 'anyOf with ${anyOf.length} items');
+    final schemas = <SchemaRef>[];
+    for (var i = 0; i < anyOf.length; i++) {
+      schemas.add(parseSchemaOrRef(anyOf.indexAsMap(i)));
+    }
+    return SchemaRef.schema(
+      SchemaAnyOf(
+        pointer: json.pointer.toString(),
+        snakeName: json.snakeName,
+        schemas: schemas,
+      ),
+    );
   }
 
   return SchemaRef.schema(parseSchema(json));
@@ -517,7 +553,7 @@ Components parseComponents(MapContext? componentsJson) {
     logger.warn('Ignoring securitySchemes.');
   }
 
-  final schemas = _parseComponent<Schema>(componentsJson, 'schemas', (
+  final schemas = _parseComponent<SchemaBase>(componentsJson, 'schemas', (
     childContext,
   ) {
     final ref = parseSchemaOrRef(childContext);

--- a/packages/gen/lib/src/parser.dart
+++ b/packages/gen/lib/src/parser.dart
@@ -148,12 +148,7 @@ Parameter parseParameter(MapContext json) {
 
   if (sendIn == SendIn.path) {
     final schema = type.schema;
-    final SchemaType schemaType;
-    if (schema is Schema) {
-      schemaType = schema.type;
-    } else {
-      _error(json, 'Path parameters must be strings or integers');
-    }
+    final schemaType = schema?.type;
     if (schemaType != SchemaType.string && schemaType != SchemaType.integer) {
       _error(json, 'Path parameters must be strings or integers');
     }

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -133,22 +133,76 @@ class RefOr<T> extends Equatable {
   List<Object?> get props => [ref, object];
 }
 
-class SchemaRef extends RefOr<Schema> {
+class SchemaRef extends RefOr<SchemaBase> {
   const SchemaRef.ref(String super.ref) : super.ref();
-  const SchemaRef.schema(Schema super.schema) : super.object();
+  const SchemaRef.schema(SchemaBase super.schema) : super.object();
 
-  Schema? get schema => object;
+  SchemaBase? get schema => object;
+}
+
+sealed class SchemaBase extends Equatable {
+  const SchemaBase({
+    required this.pointer,
+    required this.snakeName,
+    required this.type,
+  });
+
+  final String pointer;
+  final String snakeName;
+  final SchemaType type;
+
+  @override
+  List<Object?> get props => [pointer, snakeName, type];
+}
+
+class SchemaAnyOf extends SchemaBase {
+  const SchemaAnyOf({
+    required super.pointer,
+    required super.snakeName,
+    required this.schemas,
+  }) : super(type: SchemaType.object);
+
+  final List<SchemaRef> schemas;
+
+  @override
+  List<Object?> get props => [super.props, schemas];
+}
+
+class SchemaAllOf extends SchemaBase {
+  const SchemaAllOf({
+    required super.pointer,
+    required super.snakeName,
+    required this.schemas,
+  }) : super(type: SchemaType.object);
+
+  final List<SchemaRef> schemas;
+
+  @override
+  List<Object?> get props => [super.props, schemas];
+}
+
+class SchemaOneOf extends SchemaBase {
+  const SchemaOneOf({
+    required super.pointer,
+    required super.snakeName,
+    required this.schemas,
+  }) : super(type: SchemaType.object);
+
+  final List<SchemaRef> schemas;
+
+  @override
+  List<Object?> get props => [super.props, schemas];
 }
 
 /// A schema is a json object that describes the shape of a json object.
 /// https://spec.openapis.org/oas/v3.0.0#schemaObject
 @immutable
-class Schema extends Equatable {
+class Schema extends SchemaBase {
   /// Create a new schema.
   Schema({
-    required this.pointer,
-    required this.snakeName,
-    required this.type,
+    required super.pointer,
+    required super.snakeName,
+    required super.type,
     required this.properties,
     required this.required,
     required this.description,
@@ -168,15 +222,6 @@ class Schema extends Equatable {
       );
     }
   }
-
-  /// Json pointer location of this schema.
-  final String pointer;
-
-  /// Name of this schema based on parse location.
-  final String snakeName;
-
-  /// The type of this schema.
-  final SchemaType type;
 
   /// The properties of this schema.
   final Map<String, SchemaRef> properties;
@@ -447,8 +492,18 @@ class Response extends Equatable {
     }
     for (final mediaType in content.values) {
       final schemaRef = mediaType.schema;
-      // This does not resolve the schema, so it will not work with refs.
-      if (schemaRef.schema?.type != SchemaType.unknown) {
+      final schema = schemaRef.schema;
+      if (schema == null) {
+        // Assume refs have content.
+        return true;
+      }
+      if (schema is Schema) {
+        // Any non-empty schema has content.
+        if (schema.type != SchemaType.unknown) {
+          return true;
+        }
+      } else {
+        // All collection-type schemas have content.
         return true;
       }
     }
@@ -467,7 +522,7 @@ class Components extends Equatable {
     this.parameters = const {},
   });
 
-  final Map<String, Schema> schemas;
+  final Map<String, SchemaBase> schemas;
   final Map<String, Parameter> parameters;
 
   // final Map<String, SecurityScheme> securitySchemes;

--- a/packages/gen/lib/src/spec.dart
+++ b/packages/gen/lib/src/spec.dart
@@ -258,9 +258,7 @@ class Schema extends SchemaBase {
 
   @override
   List<Object?> get props => [
-    pointer,
-    snakeName,
-    type,
+    super.props,
     properties,
     required,
     description,

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -14,7 +14,7 @@ void main() {
       );
     }
 
-    Map<String, Schema> parseTestSchemas(Map<String, dynamic> schemasJson) {
+    Map<String, SchemaBase> parseTestSchemas(Map<String, dynamic> schemasJson) {
       final specJson = {
         'openapi': '3.1.0',
         'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -180,7 +180,7 @@ void main() {
       };
       final logger = _MockLogger();
       final schemas = runWithLogger(logger, () => parseTestSchemas(json));
-      final schema = schemas['User']!;
+      final schema = schemas['User']! as Schema;
       expect(schema.type, SchemaType.array);
       expect(schema.items!.ref, '#/components/schemas/Value');
     });
@@ -301,7 +301,7 @@ void main() {
       };
       final logger = _MockLogger();
       final schemas = runWithLogger(logger, () => parseTestSchemas(json));
-      final schema = schemas['User']!;
+      final schema = schemas['User']! as Schema;
       expect(schema.type, SchemaType.object);
       expect(schema.properties['value']!.ref, '#/components/schemas/Value');
 

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -121,6 +121,24 @@ void main() {
         'components': {
           'schemas': {
             'Foo': {'type': 'object'},
+            'Bar': {
+              'anyOf': [
+                {'type': 'boolean'},
+                {'type': 'string'},
+              ],
+            },
+            'Baz': {
+              'allOf': [
+                {'type': 'boolean'},
+                {'type': 'string'},
+              ],
+            },
+            'Qux': {
+              'oneOf': [
+                {'type': 'boolean'},
+                {'type': 'string'},
+              ],
+            },
           },
         },
       };

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -940,6 +940,33 @@ void main() {
         ),
       ]);
     });
+
+    test('ignores securitySchemes', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+        'components': {
+          'securitySchemes': {
+            'foo': {'type': 'http'},
+          },
+        },
+      };
+      final logger = _MockLogger();
+      runWithLogger(logger, () => parseTestSpec(json));
+      verify(() => logger.warn('Ignoring securitySchemes.')).called(1);
+    });
   });
 
   group('ParseContext', () {

--- a/packages/gen/test/parser_test.dart
+++ b/packages/gen/test/parser_test.dart
@@ -198,7 +198,7 @@ void main() {
       expect(schemas['User']!.type, SchemaType.boolean);
     });
 
-    test('anyOf not generally supported', () {
+    test('anyOf parses as SchemaAnyOf', () {
       final json = {
         'User': {
           'anyOf': [
@@ -208,20 +208,8 @@ void main() {
         },
       };
       final logger = _MockLogger();
-      expect(
-        () => runWithLogger(logger, () => parseTestSchemas(json)),
-        throwsA(
-          isA<UnimplementedError>().having(
-            (e) => e.message,
-            'message',
-            equals(
-              'anyOf with 2 items not supported in '
-              'MapContext(/components/schemas/User, '
-              '{anyOf: [{type: boolean}, {type: string}]})',
-            ),
-          ),
-        ),
-      );
+      final schemas = runWithLogger(logger, () => parseTestSchemas(json));
+      expect(schemas['User'], isA<SchemaAnyOf>());
     });
 
     test('allOf with one item', () {
@@ -247,20 +235,8 @@ void main() {
         },
       };
       final logger = _MockLogger();
-      expect(
-        () => runWithLogger(logger, () => parseTestSchemas(json)),
-        throwsA(
-          isA<UnimplementedError>().having(
-            (e) => e.message,
-            'message',
-            equals(
-              'allOf with 2 items not supported in '
-              'MapContext(/components/schemas/User, '
-              '{allOf: [{type: boolean}, {type: string}]})',
-            ),
-          ),
-        ),
-      );
+      final schemas = runWithLogger(logger, () => parseTestSchemas(json));
+      expect(schemas['User'], isA<SchemaAllOf>());
     });
 
     test('oneOf not supported', () {
@@ -272,20 +248,8 @@ void main() {
         },
       };
       final logger = _MockLogger();
-      expect(
-        () => runWithLogger(logger, () => parseTestSchemas(json)),
-        throwsA(
-          isA<UnimplementedError>().having(
-            (e) => e.message,
-            'message',
-            equals(
-              'oneOf not supported in '
-              'MapContext(/components/schemas/User, '
-              '{oneOf: [{type: boolean}]})',
-            ),
-          ),
-        ),
-      );
+      final schemas = runWithLogger(logger, () => parseTestSchemas(json));
+      expect(schemas['User'], isA<SchemaOneOf>());
     });
 
     test('components schemas as ref not supported', () {


### PR DESCRIPTION
Split SchemaBase from Schema and introduced AnyOf, OneOf and AllOf subclasses of SchemaBase.